### PR TITLE
feat/infra: 외부인 SSH 포트 22 접근 제한 및 공격 방어를 위해 Github Actions Runner IP를 AWS에 동적으로 허용

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - dev
     paths:
+      - '.github/**'
       - 'ai_server/**'
 
 permissions:


### PR DESCRIPTION
## 1. 문제

* Github Actions를 통해 서버에 접속할 때 SSH 포트 22가 **모든 사용자에게 열려 있어 보안상 위험**한 상황이 발생했습니다.

---

## 2. 방법

1. **방법 고려**

   1. 동적 IP 기반 보안 그룹 관리
   2. AWS SSM(Session Manager)
   3. AWS CodeDeploy
   4. VPN 기반 접근

2. **선택**

| 순위 | 방법                      | 이유               |
| -- | ----------------------- | ---------------- |
| 1  | **SSM Session Manager** | 가장 안전, AWS 권장 방식 |
| 2  | **동적 IP 관리**            | 기존 구조 유지, 적용이 쉬움 |
| 3  | Self-hosted Runner      | SSH 자체가 필요 없어짐   |
| 4  | CodeDeploy              | 규모가 커지면 고려       |

3. **결정 이유**

* 동적 IP 관리가 **속도와 구현 난이도 측면에서 가장 빠르게 적용 가능**하다고 판단했습니다.

4. **구현**

   1. **IAM 권한 설정**

      ```json
      {
        "Version": "2012-10-17",
        "Statement": [
          {
            "Effect": "Allow",
            "Action": [
              "ec2:AuthorizeSecurityGroupIngress",
              "ec2:RevokeSecurityGroupIngress"
            ],
            "Resource": "arn:aws:ec2:ap-northeast-2:<ACCOUNT_ID>:security-group/<SECURITY_GROUP_ID>"
          }
        ]
      }
      ```

   2. **GitHub Actions 구현**

      * Runner IP를 동적으로 조회하여 AWS 보안 그룹에 추가
      * 배포 후 IP 제거
      * SSH 포트 22 접근을 필요한 시점에만 허용

---

## 3. 결과 (개선 사항 수치)

* SSH 포트 22 접근 범위 **모든 사용자 → GitHub Actions Runner IP만 허용**
* CI/CD 배포 과정에서 **보안 강화**
* 기존 배포 자동화 **유지**


