### PR TITLE
fix(solo): update keyword type to List[Any] to fix validation err

### DIFF
--- a/ai_server/app/schemas/solo.py
+++ b/ai_server/app/schemas/solo.py
@@ -43,7 +43,7 @@ class FeedbackDetail(BaseModel):
     """
 
     summarize: str
-    keyword: List[str]
+    keyword: List[Any]
     facts: str
     understanding: str
     personalized: str


### PR DESCRIPTION
##  수정 사항
- **Solo Mode 유효성 검사 오류 해결**: `gemini-3-pro-preview` 모델이 가끔 `keyword` 필드에 대해 `List[str]` 대신 리스트의 리스트(`[["keyword1"], ["keyword2"]]`)를 반환하여 발생하는 `500 Internal Server Error`를 수정.

##  변경 내용
- [app/schemas/solo.py](cci:7://file:///Users/goorm/dir_ktbai/runpod_stt/4-team-IMYME-ai/ai_server/app/schemas/solo.py:0:0-0:0): LLM의 가변적인 출력 형식을 수용하기 위해 `result.feedback.keyword` 필드의 타입을 `List[str]`에서 `List[Any]`로 변경.
- [TROUBLESHOOTING.md](cci:7://file:///Users/goorm/dir_ktbai/runpod_stt/4-team-IMYME-ai/TROUBLESHOOTING.md:0:0-0:0): 해당 Pydantic Validation Error의 발생 원인(LLM 출력 포맷 불일치)과 해결 방법에 대한 문서를 추가.

## 검증 
- 스키마가 이제 `List[str]`과 `List[List[str]]` 형태 모두 `ValidationError` 없이 정상적으로 처리하는 것을 확인.