### PR TITLE
Feat/update scoring response format

### DIFF
--- a/ai_server/app/schemas/solo.py
+++ b/ai_server/app/schemas/solo.py
@@ -57,7 +57,9 @@ class SoloResultDetail(BaseModel):
     SOLO-002: 분석 결과 상세 (점수 및 피드백)
     """
 
-    overall_score: int = Field(..., alias="overallScore", description="종합 점수 (0-100)")
+    overall_score: int = Field(
+        ..., alias="overallScore", description="종합 점수 (0-100)"
+    )
     level: int = Field(..., ge=1, le=5, description="레벨 (1-5)")
     feedback: FeedbackDetail
 

--- a/ai_server/app/schemas/solo.py
+++ b/ai_server/app/schemas/solo.py
@@ -57,9 +57,12 @@ class SoloResultDetail(BaseModel):
     SOLO-002: 분석 결과 상세 (점수 및 피드백)
     """
 
-    score: int
-    level: str
+    overall_score: int = Field(..., alias="overallScore", description="종합 점수 (0-100)")
+    level: int = Field(..., ge=1, le=5, description="레벨 (1-5)")
     feedback: FeedbackDetail
+
+    class Config:
+        populate_by_name = True
 
 
 class SoloResultData(BaseModel):

--- a/ai_server/app/services/analysis_service.py
+++ b/ai_server/app/services/analysis_service.py
@@ -54,7 +54,7 @@ class AnalysisService:
 
             # 3. Aggregate Results
             final_result = {
-                "score": score_result["score"],
+                "overall_score": score_result["overall_score"],
                 "level": score_result["level"],
                 "feedback": feedback_result,
             }

--- a/ai_server/app/services/scoring_service.py
+++ b/ai_server/app/services/scoring_service.py
@@ -32,7 +32,10 @@ class ScoringService:
             )
             result = json.loads(cleaned_text)
 
-            return {"score": result.get("score", 0), "level": result.get("level", "C")}
+            return {
+                "overall_score": result.get("overall_score", 0),
+                "level": result.get("level", 1),
+            }
         except Exception as e:
             logger.error(f"Scoring failed: {e}")
             # Return a fallback or re-raise depending on policy.
@@ -53,8 +56,8 @@ class ScoringService:
         [Output Format]
         Return purely JSON without any markdown formatting.
         {{
-            "score": <0-100 integer>,
-            "level": <"S", "A", "B", "C">
+            "overall_score": <0-100 integer>,
+            "level": <1-5 integer>
         }}
         """
 


### PR DESCRIPTION
## 📝 PR Description

### Title
feat!: Update Scoring Response Format (Overall Score & Integer Level)

### Description
**배경 (Context)**
기존 심층 분석(`Solo`) 결과의 `score` 필드명이 모호하고, `level`이 문제풀이 결과(S/A/B/C)와 혼동될 여지가 있어 명확한 수치형 데이터로 개선이 필요했습니다.

**변경 사항 (Changes)**
1.  **Field Rename**: `score` -> **`overall_score`** (JSON alias: `overallScore`)
    -   FE에서는 `overallScore`로 접근해야 합니다.
2.  **Type Change**: `level` (Str) -> **`level` (Int, 1-5)**
    -   기존: "S", "A", "B", "C"
    -   변경: 1 (Lowest) ~ 5 (Highest)
3.  **Default Logic**: LLM 오류 시 `0`점, `1`레벨을 반환하도록 방어 로직을 강화했습니다.

**영향 범위 (Impact)**
- **Breaking Change**: FE에서 분석 결과(`SoloResultResponse`)를 파싱하는 부분의 수정이 필요합니다.
- API 문서(Swagger)의 스키마가 변경되었습니다.

### How to Test
1. Call `POST /api/v1/solo/submissions` to create a task.
2. Poll `GET /api/v1/solo/submissions/{taskId}`.
3. Verify the `result` object structure:
    ```json
    {
      "overallScore": 85,
      "level": 4, // Integer 1-5
      "feedback": { ... }
    }
    ```