### PR TITLE
Feat/ai server auth

### DIFF
--- a/ai_server/app/core/config.py
+++ b/ai_server/app/core/config.py
@@ -27,6 +27,9 @@ class Settings(BaseSettings):
     # Root path for reverse proxy (e.g. /ai)
     ROOT_PATH: str = ""
 
+    # Internal Secret for Middleware Auth
+    INTERNAL_SECRET_KEY: str = ""
+
     class Config:
         # Load settings from .env file if present
         # .env 파일이 존재하면 설정을 로드함

--- a/ai_server/app/main.py
+++ b/ai_server/app/main.py
@@ -1,4 +1,5 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
 from app.api.v1.router import api_router
 from app.core.config import settings
 import logging
@@ -14,6 +15,30 @@ app = FastAPI(
     openapi_url=f"{settings.API_V1_STR}/openapi.json",
     root_path=settings.ROOT_PATH,
 )
+
+@app.middleware("http")
+async def verify_internal_secret(request: Request, call_next):
+    # 1. Skip checks for Health Check or Docs
+    # 헬스 체크나 문서는 통과
+    # Also skip ROOT_PATH if it exists in request (Reverse Proxy handling)
+    path = request.url.path
+    if settings.ROOT_PATH and path.startswith(settings.ROOT_PATH):
+        path = path[len(settings.ROOT_PATH):]
+
+    if path in ["/health", "/docs", "/openapi.json", "/", settings.API_V1_STR + "/openapi.json"]:
+        return await call_next(request)
+
+    # 2. Check Header
+    # 헤더 검사
+    if not settings.INTERNAL_SECRET_KEY:
+        # If no secret set in env, allow all (or block all? user didn't specify, assuming allow for dev convenience or block for safety)
+        # Let's perform check only if key is set.
+        pass 
+    elif request.headers.get("x-internal-secret") != settings.INTERNAL_SECRET_KEY:
+        return JSONResponse(status_code=403, content={"detail": "Access Denied: Invalid Internal Secret"})
+
+    response = await call_next(request)
+    return response
 
 # Include API routers
 # API 라우터 포함

--- a/ai_server/app/main.py
+++ b/ai_server/app/main.py
@@ -16,6 +16,7 @@ app = FastAPI(
     root_path=settings.ROOT_PATH,
 )
 
+
 @app.middleware("http")
 async def verify_internal_secret(request: Request, call_next):
     # 1. Skip checks for Health Check or Docs
@@ -23,9 +24,15 @@ async def verify_internal_secret(request: Request, call_next):
     # Also skip ROOT_PATH if it exists in request (Reverse Proxy handling)
     path = request.url.path
     if settings.ROOT_PATH and path.startswith(settings.ROOT_PATH):
-        path = path[len(settings.ROOT_PATH):]
+        path = path[len(settings.ROOT_PATH) :]
 
-    if path in ["/health", "/docs", "/openapi.json", "/", settings.API_V1_STR + "/openapi.json"]:
+    if path in [
+        "/health",
+        "/docs",
+        "/openapi.json",
+        "/",
+        settings.API_V1_STR + "/openapi.json",
+    ]:
         return await call_next(request)
 
     # 2. Check Header
@@ -33,12 +40,16 @@ async def verify_internal_secret(request: Request, call_next):
     if not settings.INTERNAL_SECRET_KEY:
         # If no secret set in env, allow all (or block all? user didn't specify, assuming allow for dev convenience or block for safety)
         # Let's perform check only if key is set.
-        pass 
+        pass
     elif request.headers.get("x-internal-secret") != settings.INTERNAL_SECRET_KEY:
-        return JSONResponse(status_code=403, content={"detail": "Access Denied: Invalid Internal Secret"})
+        return JSONResponse(
+            status_code=403,
+            content={"detail": "Access Denied: Invalid Internal Secret"},
+        )
 
     response = await call_next(request)
     return response
+
 
 # Include API routers
 # API 라우터 포함


### PR DESCRIPTION
### Description
**개요**
AI 서버의 보안 강화를 위해 내부 통신용 인증 미들웨어를 도입했습니다.
이제 `/health` 및 Swagger 문서를 제외한 모든 API 요청 시 `X-Internal-Secret` 헤더 검증이 필요합니다.

**변경 사항**
- **Auth Middleware**: `main.py`에 `verify_internal_secret` 미들웨어 추가
- **Configuration**: 환경 변수(`INTERNAL_SECRET_KEY`)를 통해 비밀키 관리하도록 `config.py` 수정
- **Exception Handling**: 비밀키 불일치 시 `403 Forbidden` 반환

**테스트 방법**
1. `.env`에 `INTERNAL_SECRET_KEY` 설정
2. 헤더 없이 API 요청 시 -> `403 Forbidden` 확인
3. 올바른 헤더(`x-internal-secret`) 포함 요청 시 -> `200 OK` 확인
