### PR TITLE
fix: Allow public access to Swagger UI documentation endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,35 @@
+# Python
 __pycache__/
 *.py[cod]
 *$py.class
 *.so
+.pytest_cache/
+.mypy_cache/
+.coverage
+htmlcov/
+
+# Environments
 .env
-.DS_Store
-.vscode/
-.idea/
+.env.*
+!.env.example
+ai_server/.env
+stt_server/.env
 venv/
 env/
+
+# IDE
+.vscode/
+.idea/
+
+# OS
+.DS_Store
+
+# Distribution / Build
 dist/
 build/
 *.egg-info/
-ai_server/.env
-stt_server/.env
+
+# Secrets
+*.key
+*.pem
+*.p12

--- a/ai_server/app/main.py
+++ b/ai_server/app/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, Request, Depends, Security
+from fastapi import FastAPI, Request, Security
 from fastapi.responses import JSONResponse
 from fastapi.security import APIKeyHeader
 from app.api.v1.router import api_router
@@ -18,7 +18,7 @@ app = FastAPI(
     title=settings.PROJECT_NAME,
     openapi_url=f"{settings.API_V1_STR}/openapi.json",
     root_path=settings.ROOT_PATH,
-    dependencies=[Security(api_key_header)], # Add Global Security
+    dependencies=[Security(api_key_header)],  # Add Global Security
 )
 
 

--- a/ai_server/app/main.py
+++ b/ai_server/app/main.py
@@ -1,5 +1,6 @@
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Depends, Security
 from fastapi.responses import JSONResponse
+from fastapi.security import APIKeyHeader
 from app.api.v1.router import api_router
 from app.core.config import settings
 import logging
@@ -8,12 +9,16 @@ import logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("whoo-ai-server")
 
+# Swagger Auth
+api_key_header = APIKeyHeader(name="x-internal-secret", auto_error=False)
+
 # Initialize FastAPI app
 # FastAPI 앱 초기화
 app = FastAPI(
     title=settings.PROJECT_NAME,
     openapi_url=f"{settings.API_V1_STR}/openapi.json",
     root_path=settings.ROOT_PATH,
+    dependencies=[Security(api_key_header)], # Add Global Security
 )
 
 


### PR DESCRIPTION
### Description

## � Bug Report
**Problem**:
`ai_server`에 내부 인증(`x-internal-secret`) 미들웨어가 적용되면서, 개발 편의를 위한 Swagger 문서 페이지(`/docs`, `/openapi.json`)까지 인증 헤더 없이는 접근이 불가능(`403 Forbidden`)해지는 문제가 발생.

**Cause**:
`verify_internal_secret` 미들웨어에서 문서화 관련 경로에 대한 예외 처리가 누락.

## 🛠 Solution
- 미들웨어 내 예외 경로(`allowed_paths`)에 `/docs`, `/openapi.json`, `API_V1_STR/openapi.json` 등을 추가하여 인증 로직을 건너뛰도록 수정.

## ✅ Verification
- 브라우저에서 `http://localhost:8000/docs` 접속 시 403 에러 없이 Swagger UI가 로딩되는지 확인.
```
