### PR TITLE
Feat/expand audio formats

### DIFF
--- a/ai_server/app/api/v1/endpoints/transcription.py
+++ b/ai_server/app/api/v1/endpoints/transcription.py
@@ -42,7 +42,7 @@ async def transcribe_audio(request: TranscriptionRequest):
 
     # 2. Validate File Extension (UNSUPPORTED_FORMAT - 400)
     # 파일 확장자 검증
-    supported_formats = [".mp3", ".wav", ".m4a", ".flac", ".ogg", ".aac", ".wma"]
+    supported_formats = [".mp3", ".wav", ".m4a", ".flac", ".ogg", ".aac", ".wma", ".webm", ".mp4"]
     # Check if URL ends with supported extension (ignoring query params)
     clean_url = request.audio_url.split("?")[0].lower()
     if not any(clean_url.endswith(ext) for ext in supported_formats):

--- a/ai_server/app/api/v1/endpoints/transcription.py
+++ b/ai_server/app/api/v1/endpoints/transcription.py
@@ -42,7 +42,17 @@ async def transcribe_audio(request: TranscriptionRequest):
 
     # 2. Validate File Extension (UNSUPPORTED_FORMAT - 400)
     # 파일 확장자 검증
-    supported_formats = [".mp3", ".wav", ".m4a", ".flac", ".ogg", ".aac", ".wma", ".webm", ".mp4"]
+    supported_formats = [
+        ".mp3",
+        ".wav",
+        ".m4a",
+        ".flac",
+        ".ogg",
+        ".aac",
+        ".wma",
+        ".webm",
+        ".mp4",
+    ]
     # Check if URL ends with supported extension (ignoring query params)
     clean_url = request.audio_url.split("?")[0].lower()
     if not any(clean_url.endswith(ext) for ext in supported_formats):

--- a/ai_server/app/services/knowledge_service.py
+++ b/ai_server/app/services/knowledge_service.py
@@ -136,7 +136,9 @@ class KnowledgeService:
 
             return KnowledgeEvaluationResult(
                 decision=decision,
-                targetId=str(data.get("targetId")) if data.get("targetId") is not None else None,
+                targetId=str(data.get("targetId"))
+                if data.get("targetId") is not None
+                else None,
                 finalContent=final_content,
                 finalVector=final_vector,
                 reasoning=data.get("reasoning", ""),

--- a/ai_server/app/services/knowledge_service.py
+++ b/ai_server/app/services/knowledge_service.py
@@ -136,7 +136,7 @@ class KnowledgeService:
 
             return KnowledgeEvaluationResult(
                 decision=decision,
-                targetId=data.get("targetId"),
+                targetId=str(data.get("targetId")) if data.get("targetId") is not None else None,
                 finalContent=final_content,
                 finalVector=final_vector,
                 reasoning=data.get("reasoning", ""),


### PR DESCRIPTION
## 📝 Summary
STT 전사 API(`POST /transcriptions`)에서 지원하는 오디오 포맷 리스트를 확장.

## 🛠 Changes
- **[app/api/v1/endpoints/transcription.py](cci:7://file:///Users/goorm/dir_ktbai/runpod_stt/4-team-IMYME-ai/ai_server/app/api/v1/endpoints/transcription.py:0:0-0:0)**:
  - `supported_formats` 리스트에 `.webm` 및 `.mp4` 추가. (Ruff formatting 적용)

## 🔍 Context
Faster Whisper 모델(FFmpeg)은 해당 포맷들을 이미 지원하지만, API 레벨의 검증 리스트(`supported_formats`)에서 누락되어 있었음. 이를 해제하여 브라우저 녹음 파일(.webm)이나 비디오 파일(.mp4)도 별도 변환 없이 처리할 수 있도록 개선함.

## ✅ Verification
- API 엔드포인트에 `.webm`, `.mp4` 확장자로 요청 시 정상 처리 확인
- `ruff format` 자동 적용 완료