### PR TITLE
fix: Enforce plain text in feedback prompts and resolve Runpod client…

### DIFF
--- a/ai_server/app/core/prompts.py
+++ b/ai_server/app/core/prompts.py
@@ -29,7 +29,8 @@ You are an expert AI Learning Coach. Your goal is to strictly evaluate the user'
         - Secondary: ONLY IF `History` provided relevant context (recurrence/improvement), weave that into the commentary. Otherwise, focus on the current answer's quality.
 
 [Output Format]
-Output a single valid JSON object. Do not include markdown formatting.
+Output a single valid JSON object.
+**Strictly NO Markdown**: The values inside the JSON must be plain text. Do NOT use bold (**text**), italics (*text*), or any markdown syntax.
 
 {{
   "summarize": "A one-sentence summary of the user's understanding level and main points in Korean.",


### PR DESCRIPTION
## 🐛 Bug Fixes
- **RunPod Client**: Resolved a `NameError` where [settings](cci:1://file:///Users/goorm/dir_ktbai/runpod_stt/4-team-IMYME-ai/ai_server/app/core/config.py:40:0-42:21) was not imported in [runpod_client.py](cci:7://file:///Users/goorm/dir_ktbai/runpod_stt/4-team-IMYME-ai/ai_server/app/services/runpod_client.py:0:0-0:0), causing the application to crash when accessing RunPod configurations.

## 🎨 Prompt Engineering
- **Markdown Restriction**: Updated `BASE_SYSTEM_PROMPT` to explicitly forbid markdown syntax (such as `**bold**`, `*italics*`) within the JSON expectation.
- **Reason**: To ensure [FeedbackService](cci:2://file:///Users/goorm/dir_ktbai/runpod_stt/4-team-IMYME-ai/ai_server/app/services/feedback_service.py:10:0-42:19) returns clean, plain text for better UI consistency and to prevent raw markdown from being displayed to the user.