### PR TITLE
[HOTFIX] Solo API: allow empty text(400 error)

### DIFF
--- a/ai_server/app/schemas/solo.py
+++ b/ai_server/app/schemas/solo.py
@@ -13,7 +13,6 @@ class SoloSubmissionRequest(BaseModel):
     user_text: str = Field(
         ...,
         alias="userText",
-        min_length=1,
         description="Step 1에서 변환된 사용자 발화 텍스트",
     )
     criteria: Dict[str, Any] = Field(..., description="정답지 및 모델 가이드 (JSON)")


### PR DESCRIPTION
## 🔴 문제 상황 (Issue)

API 에러: STT 인식 실패 등으로 userText가 빈 문자열("")로 들어오면, AI Server가 400 Bad Request (Validation Error)를 반환함.
메인 서버 장애: Main Server(Spring Boot)는 비동기 분석 요청 후 성공(2xx) 응답을 가정하고 Polling을 시작하거나 대기하는데, 예상치 못한 400 에러로 인해 무한 대기(Infinite Wait) 상태에 빠짐.
사용자 경험: 클라이언트 브라우저에서 분석 로딩이 멈추지 않는 치명적인 UX 문제 발생.

## 🟢 해결 방안 (Solution)

Schema 수정 (app/schemas/solo.py): 
userText 필드의 min_length=1 제약 조건을 삭제.
빈 문자열 입력 시에도 202 Accepted를 즉시 반환.
Service 로직 활용:
이미 analysis_service.py에 구현된 "5글자 미만 텍스트 처리 로직"을 통해, 빈 문자열은 0점 및 안내 피드백으로 정상 처리(COMPLETED)됨.
결과: Main Server는 202 응답을 받고 Polling을 수행하다가 "완료" 상태를 감지하여 정상적으로 프로세스를 종료할 수 있음.

## 🛡️ 안전성 검증 (Safety Check)

Defense-in-Depth: 스키마 제약이 없어져도 Service Layer에서 len(text) < 5 체크를 통해 LLM 호출을 건너뛰므로 비용 문제나 로직 오류 없음.
Test: 
test_solo.py에 빈 텍스트 제출 테스트(
test_success_submit_empty_text
) 추가 및 통과 확인.
Null Safety: None(null)값은 여전히 400 에러로 막히며, 오직 빈 문자열("")만 허용됨.

## 📸 관련 스크린샷/로그 (선택 사항: 400 에러 로그나 테스트 통과 캡처 첨부)
<img width="1177" height="147" alt="image" src="https://github.com/user-attachments/assets/3e032970-acba-4217-b97a-0f16200cf342" />
<img width="1512" height="982" alt="image" src="https://github.com/user-attachments/assets/2451848d-6ba0-42ed-af67-21e4c6a23c8c" />


