### PR TITLE
infra: AI Docker 기반 CI/CD 전환 및 release→main 배포 구조 도입

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -1,4 +1,4 @@
-name: AI CI/CD v3
+name: AI CI/CD Docker main
 
 on:
   pull_request:
@@ -30,10 +30,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.11
+      - name: Set up Python 3.10
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.10"
 
       - name: Cache pip
         uses: actions/cache@v4
@@ -94,196 +94,110 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # 0️⃣ Runner IP 획득 및 보안 그룹 추가
-      - name: Get Runner IP
-        id: ip
-        run: echo "ipv4=$(curl -s https://api.ipify.org)" >> $GITHUB_OUTPUT
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-      - name: Add IP to Security Group
-        run: |
-          aws ec2 authorize-security-group-ingress \
-            --group-id ${{ secrets.AWS_SECURITY_GROUP_ID }} \
-            --protocol tcp \
-            --port 22 \
-            --cidr "${{ steps.ip.outputs.ipv4 }}/32"
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ap-northeast-2
+      # AWS 인증
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
 
-      - name: Set up SSH
-        run: |
-          mkdir -p ~/.ssh
-          echo "${{ secrets.DEV_SERVER_SSH_KEY }}" > ~/.ssh/id_rsa
-          chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan -H ${{ secrets.PROD_SERVER_HOST }} >> ~/.ssh/known_hosts
+      # ECR 로그인 후 docker push 가능 상태로 전환
+      - name: Login to ECR
+        uses: aws-actions/amazon-ecr-login@v2
 
-      - name: Deploy AI Server
+      # Buildx 사용 + GHA 캐시로 이미지 빌드 속도 개선
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Docker 이미지 빌드 & 푸시
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./ai_server
+          file: ./ai_server/Dockerfile
+          push: true
+          platforms: linux/arm64
+          tags: |
+            219268921033.dkr.ecr.ap-northeast-2.amazonaws.com/imyme-ai:${{ github.sha }}
+            219268921033.dkr.ecr.ap-northeast-2.amazonaws.com/imyme-ai:prod-latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # SSM으로 서버에 배포
+      - name: Deploy via SSM
         run: |
-          ssh -i ~/.ssh/id_rsa ubuntu@${{ secrets.PROD_SERVER_HOST }} 'bash -s' <<'EOF'
           set -euo pipefail
 
-          APP_ROOT=/home/ubuntu/mine/ai
-          RELEASES_DIR=$APP_ROOT/releases
-          SHARED_DIR=$APP_ROOT/shared
-          CURRENT_LINK=$APP_ROOT/current
+          IMAGE_URI="219268921033.dkr.ecr.ap-northeast-2.amazonaws.com/imyme-ai:prod-latest"
 
-          # 릴리즈 식별자(초 단위)
-          RELEASE_ID=$(date +%Y%m%d%H%M%S)
-          RELEASE_DIR=$RELEASES_DIR/$RELEASE_ID
+          cat > /tmp/ssm-params.json << 'EOF'
+          {
+            "commands": [
+              "set -eu",
+              "cd /home/ubuntu",
+              "aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin 219268921033.dkr.ecr.ap-northeast-2.amazonaws.com",
+              "> /home/ubuntu/.env",
+              "echo '# ------------- COMMON --------------' >> /home/ubuntu/.env",
+              "aws ssm get-parameters-by-path --path '/MINE/MVP1/AI/ENV/COMMON' --with-decryption --query 'Parameters[*].[Name,Value]' --output text --region ap-northeast-2 | while IFS=$(printf '\\t') read -r name value; do key=$(basename \"$name\"); echo \"$key=${value:-}\" >> /home/ubuntu/.env; done",
+              "echo '' >> /home/ubuntu/.env",
+              "echo '# ------------- PROD --------------' >> /home/ubuntu/.env",
+              "aws ssm get-parameters-by-path --path '/MINE/MVP1/AI/ENV/PROD' --with-decryption --query 'Parameters[*].[Name,Value]' --output text --region ap-northeast-2 | while IFS=$(printf '\\t') read -r name value; do key=$(basename \"$name\"); echo \"$key=${value:-}\" >> /home/ubuntu/.env; done",
+              "IMAGE_URI=219268921033.dkr.ecr.ap-northeast-2.amazonaws.com/imyme-ai:prod-latest",
+              "docker pull $IMAGE_URI",
+              "docker compose up -d",
+              "docker image prune -f"
+            ]
+          }
+          EOF
 
-          # 로그/환경변수/프로세스 관리 파일
-          LOG_DIR=$SHARED_DIR/logs
-          LOG_FILE=$LOG_DIR/ai.log
-          ENV_FILE=$SHARED_DIR/.env
-          PID_FILE=$SHARED_DIR/ai.pid
+          COMMAND_ID=$(aws ssm send-command \
+            --document-name "AWS-RunShellScript" \
+            --targets "Key=tag:aws:autoscaling:groupName,Values=mine_mvp1_ai_asg-prod" \
+            --comment "AI prod deploy (${GITHUB_SHA})" \
+            --parameters file:///tmp/ssm-params.json \
+            --region ap-northeast-2 \
+            --query "Command.CommandId" \
+            --output text)
 
-          # venv는 shared에 1개만 유지(릴리즈별 생성 X)
-          VENV_DIR=$SHARED_DIR/.venv
+          echo "SSM Command ID: ${COMMAND_ID}"
 
-          # 원격 레포 URL
-          REPO_URL="https://github.com/100-hours-a-week/4-team-IMYME-ai.git"
-          BRANCH="main"
+          for i in {1..60}; do
+            STATUS=$(aws ssm list-commands \
+              --command-id "${COMMAND_ID}" \
+              --region ap-northeast-2 \
+              --query "Commands[0].Status" \
+              --output text)
+            echo "SSM status: ${STATUS}"
 
-          echo "🚀 AI Deploy start (release/current)"
-
-          mkdir -p "$RELEASES_DIR" "$SHARED_DIR" "$LOG_DIR"
-
-          # 환경변수 파일 존재 확인
-          if [ ! -f "$SHARED_DIR/.env" ]; then
-            echo "❌ shared .env not found: $SHARED_DIR/.env"
-            exit 1
-          fi
-
-          # 새 릴리즈 폴더에 코드 스냅샷 저장
-          echo "📦 Create new release: $RELEASE_DIR"
-          mkdir -p "$RELEASE_DIR"
-
-          echo "📥 Clone repo snapshot (depth=1, branch=$BRANCH)"
-          git clone --depth 1 --branch "$BRANCH" "$REPO_URL" "$RELEASE_DIR"
-          # --depth 1 : 최신 커밋만 받아서 빠름
-          # 릴리즈 폴더에 “그 시점 코드”가 그대로 남음 → 롤백 가능해짐
-
-          # 가상환경 준비 + 의존성 설치
-          echo "🛠 Prepare venv: $VENV_DIR"
-
-          if [ ! -d "$VENV_DIR" ]; then
-            echo "📦 Creating shared virtual environment"
-            python3 -m venv "$VENV_DIR"
-          fi
-
-          # venv 활성화
-          source "$VENV_DIR/bin/activate"
-
-          echo "📦 Install dependencies"
-          pip install --upgrade pip
-
-          # requirements는 “새 릴리즈(current 기준)”의 파일을 기준으로 설치/업데이트
-          pip install -r "$RELEASE_DIR/ai_server/requirements.txt"
-
-          # 기존 프로세스 종료 (pid 파일 기준)
-          echo "🛑 Stop existing AI process (pid file)"
-          if [ -f "$PID_FILE" ]; then
-            OLD_PID=$(cat "$PID_FILE" || true)
-            if [ -n "${OLD_PID:-}" ] && kill -0 "$OLD_PID" 2>/dev/null; then
-              echo " - stopping pid=$OLD_PID"
-              kill "$OLD_PID" || true
-
-              # 종료 확인(최대 10초)
-              for i in {1..10}; do
-                if kill -0 "$OLD_PID" 2>/dev/null; then
-                  echo "   waiting... ($i/10)"
-                  sleep 1
-                else
-                  echo "   stopped"
-                  break
-                fi
-              done
-
-              # 그래도 살아있으면 강제 종료
-              if kill -0 "$OLD_PID" 2>/dev/null; then
-                echo " - still alive, SIGKILL"
-                kill -9 "$OLD_PID" || true
-              fi
-            else
-              echo " - pid file exists but process not running (pid=$OLD_PID)"
-            fi
-          else
-            echo " - pid file not found (maybe not running)"
-          fi
-
-          # 포트 점유 프로세스 무조건 종료
-          PIDS=$(lsof -t -i :8000 -nP 2>/dev/null || true)
-
-          if [ -n "${PIDS:-}" ]; then
-            echo " - found: $PIDS"
-            kill $PIDS || true
-
-            # 최대 10초 대기
-            for i in {1..10}; do
-              if lsof -t -i :8000 -nP >/dev/null 2>&1; then
-                echo "   waiting port release... ($i/10)"
-                sleep 1
-              else
-                echo "   port 8000 released"
-                break
-              fi
-            done
-
-            # 아직도 점유 중이면 강제 종료
-            if lsof -t -i :8000 -nP >/dev/null 2>&1; then
-              echo " - still in use, SIGKILL"
-              kill -9 $(lsof -t -i :8000 -nP 2>/dev/null || true) || true
-            fi
-          fi
-
-          # current 심볼릭 링크 교체 
-          echo "🔁 Switch current -> $RELEASE_DIR"
-          ln -sfn "$RELEASE_DIR" "$CURRENT_LINK"
-
-          # 서버 시작
-          echo "▶ Start AI server (current)"
-
-          # env를 export 상태로 로드하여 uvicorn에 전달
-          set -a
-          source "$ENV_FILE"
-          set +a
-
-          # current 기준으로 실행
-          cd "$CURRENT_LINK/ai_server"
-
-          nohup uvicorn app.main:app \
-            --host 0.0.0.0 \
-            --port 8000 \
-            >> "$LOG_FILE" 2>&1 </dev/null &
-
-          NEW_PID=$!
-          echo "$NEW_PID" > "$PID_FILE"
-          echo "✅ AI server started (pid=$NEW_PID)"
-
-          # 헬스체크 (로컬)
-          echo "🔍 Health check"
-          for i in {1..10}; do
-            if curl -sf http://127.0.0.1:8000/ > /dev/null; then
-              echo "✅ Health check passed"
+            if [ "${STATUS}" = "Success" ]; then
               break
             fi
-            echo "⏳ Waiting for server..."
-            sleep 2
+
+            if [ "${STATUS}" = "Failed" ] || [ "${STATUS}" = "Cancelled" ] || [ "${STATUS}" = "TimedOut" ] || [ "${STATUS}" = "Cancelling" ]; then
+              aws ssm list-command-invocations \
+                --command-id "${COMMAND_ID}" \
+                --details \
+                --region ap-northeast-2 \
+                --output json
+              exit 1
+            fi
+
+            sleep 10
           done
 
-          if ! curl -sf http://127.0.0.1:8000/ > /dev/null; then
-            echo "❌ Health check failed"
-            tail -n 200 "$LOG_FILE" || true
+          if [ "${STATUS}" != "Success" ]; then
+            echo "SSM deploy timeout"
+            aws ssm list-command-invocations \
+              --command-id "${COMMAND_ID}" \
+              --details \
+              --region ap-northeast-2 \
+              --output json
             exit 1
           fi
-
-          # 오래된 릴리즈 정리 (최근 3개만 보관)
-          echo "🧹 Cleanup old releases (keep last 3)"
-          ls -1dt "$RELEASES_DIR"/* | tail -n +4 | xargs -r rm -rf
-
-          echo "🎉 AI Deploy finished"
-          EOF
 
       # 배포 후 스모크 테스트
       - name: Post-deploy Smoke Test (AI)
@@ -293,10 +207,25 @@ jobs:
           BASE_URL="${{ secrets.PROD_BASE_URL }}"
 
           echo "🔎 Smoke 1) /ai/health should return 200"
-          curl -fsS "${BASE_URL}/ai/health" >/dev/null
+          # 1. 헬스체크 (최대 120초 대기)
+          for i in $(seq 1 12); do
+            echo "Attempt $i/12..."
+            if curl -fsS "${BASE_URL}/ai/health" >/dev/null 2>&1; then
+              echo "✅ Health check passed"
+              break
+            fi
+            sleep 10
+          done
 
-          echo "🔎 Smoke 2) POST ai/api/v1/knowledge/candidates/batch should succeed"
-          # 응답을 파일로 저장하고 HTTP 상태코드 분리
+          # health 실패하면 종료
+          curl -fsS "${BASE_URL}/ai/health" >/dev/null || {
+            echo "❌ Health check failed"
+            exit 1
+          }
+
+          echo "🔎 Testing batch API..."
+
+          # 2. 실제 API 호출
           HTTP_CODE=$(curl --max-time 180 -sS -o /tmp/ai_batch_resp.json -w "%{http_code}" \
             -X POST "${BASE_URL}/ai/api/v1/knowledge/candidates/batch" \
             -H "Content-Type: application/json" \
@@ -311,35 +240,21 @@ jobs:
               ]
             }')
 
-          # 상태코드가 200~299 사이인지 확인.
-          [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ] || {
+          # 3. HTTP 상태코드 검증 (2xx만 통과)
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
             echo "❌ HTTP $HTTP_CODE"
             cat /tmp/ai_batch_resp.json
             exit 1
-          }
+          fi
 
-          # 응답 JSON 안에 "success": true가 포함되어 있는지 확인.
+          # 4. 응답 JSON 검증
           grep -q '"success"[[:space:]]*:[[:space:]]*true' /tmp/ai_batch_resp.json || {
             echo "❌ success=true not found"
             cat /tmp/ai_batch_resp.json
             exit 1
           }
 
-          echo "✅ AI smoke tests passed"
-
-      # 5️⃣ 보안 그룹에서 IP 제거 (항상 실행)
-      - name: Remove IP from Security Group
-        if: always()
-        run: |
-          aws ec2 revoke-security-group-ingress \
-            --group-id ${{ secrets.AWS_SECURITY_GROUP_ID }} \
-            --protocol tcp \
-            --port 22 \
-            --cidr "${{ steps.ip.outputs.ipv4 }}/32"
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: ap-northeast-2
+          echo "🎉 AI smoke tests passed"
 
   cd-notify-success:
     needs: cd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,284 @@
+name: AI CI/CD release
+
+on:
+  pull_request:
+    branches:
+      - release
+    paths:
+      - ".github/**"
+      - "ai_server/**"
+  push:
+    branches:
+      - release
+    paths:
+      - ".github/**"
+      - "ai_server/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ai-cicd-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # 1) CI
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Cache pip
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('ai_server/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install -r ai_server/requirements.txt
+          pip install ruff pytest
+
+      - name: Run Ruff Lint
+        run: ruff check ai_server/
+
+      - name: Run Ruff Format Check
+        run: ruff format --check ai_server/
+
+      - name: Run Tests
+        working-directory: ai_server
+        run: pytest || echo "No tests found, skipping."
+
+  ci-notify-success:
+    needs: ci
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Discord CI success
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_AI }}
+          status: success
+          title: "🟢 AI CI Success"
+          content: "<@&${{ secrets.AI_ROLE_ID }}> AI CI 성공!"
+          color: 0x00FF00
+
+  ci-notify-failure:
+    needs: ci
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Discord CI failure
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_AI }}
+          status: failure
+          title: "🔴 AI CI Failed"
+          content: "<@&${{ secrets.AI_ROLE_ID }}> AI CI 실패!"
+          color: 0xFF0000
+
+  # 2) CD
+  cd:
+    needs: ci
+    if: github.event_name == 'push' && github.ref == 'refs/heads/release'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # AWS 인증
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      # ECR 로그인 후 docker push 가능 상태로 전환
+      - name: Login to ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      # Buildx 사용 + GHA 캐시로 이미지 빌드 속도 개선
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Docker 이미지 빌드 & 푸시
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./ai_server
+          file: ./ai_server/Dockerfile
+          push: true
+          platforms: linux/arm64
+          tags: |
+            219268921033.dkr.ecr.ap-northeast-2.amazonaws.com/imyme-ai:${{ github.sha }}
+            219268921033.dkr.ecr.ap-northeast-2.amazonaws.com/imyme-ai:release-latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # SSM으로 서버에 배포
+      - name: Deploy via SSM
+        run: |
+          set -euo pipefail
+
+          IMAGE_URI="219268921033.dkr.ecr.ap-northeast-2.amazonaws.com/imyme-ai:release-latest"
+
+          cat > /tmp/ssm-params.json << 'EOF'
+          {
+            "commands": [
+              "set -eu",
+              "cd /home/ubuntu",
+              "aws ecr get-login-password --region ap-northeast-2 | docker login --username AWS --password-stdin 219268921033.dkr.ecr.ap-northeast-2.amazonaws.com",
+              "> /home/ubuntu/.env",
+              "echo '# ------------- COMMON --------------' >> /home/ubuntu/.env",
+              "aws ssm get-parameters-by-path --path '/MINE/MVP1/AI/ENV/COMMON' --with-decryption --query 'Parameters[*].[Name,Value]' --output text --region ap-northeast-2 | while IFS=$(printf '\\t') read -r name value; do key=$(basename \"$name\"); echo \"$key=${value:-}\" >> /home/ubuntu/.env; done",
+              "echo '' >> /home/ubuntu/.env",
+              "echo '# ------------- RELEASE --------------' >> /home/ubuntu/.env",
+              "aws ssm get-parameters-by-path --path '/MINE/MVP1/AI/ENV/RELEASE' --with-decryption --query 'Parameters[*].[Name,Value]' --output text --region ap-northeast-2 | while IFS=$(printf '\\t') read -r name value; do key=$(basename \"$name\"); echo \"$key=${value:-}\" >> /home/ubuntu/.env; done",
+              "docker pull $IMAGE_URI",
+              "docker compose up -d",
+              "docker image prune -f"
+            ]
+          }
+          EOF
+
+          COMMAND_ID=$(aws ssm send-command \
+            --document-name "AWS-RunShellScript" \
+            --targets "Key=tag:aws:autoscaling:groupName,Values=mine_mvp1_ai_asg" \
+            --comment "AI release deploy (${GITHUB_SHA})" \
+            --parameters file:///tmp/ssm-params.json \
+            --region ap-northeast-2 \
+            --query "Command.CommandId" \
+            --output text)
+
+          echo "SSM Command ID: ${COMMAND_ID}"
+
+          for i in {1..60}; do
+            STATUS=$(aws ssm list-commands \
+              --command-id "${COMMAND_ID}" \
+              --region ap-northeast-2 \
+              --query "Commands[0].Status" \
+              --output text)
+            echo "SSM status: ${STATUS}"
+
+            if [ "${STATUS}" = "Success" ]; then
+              break
+            fi
+
+            if [ "${STATUS}" = "Failed" ] || [ "${STATUS}" = "Cancelled" ] || [ "${STATUS}" = "TimedOut" ] || [ "${STATUS}" = "Cancelling" ]; then
+              aws ssm list-command-invocations \
+                --command-id "${COMMAND_ID}" \
+                --details \
+                --region ap-northeast-2 \
+                --output json
+              exit 1
+            fi
+
+            sleep 10
+          done
+
+          if [ "${STATUS}" != "Success" ]; then
+            echo "SSM deploy timeout"
+            aws ssm list-command-invocations \
+              --command-id "${COMMAND_ID}" \
+              --details \
+              --region ap-northeast-2 \
+              --output json
+            exit 1
+          fi
+
+      # 배포 후 스모크 테스트
+      - name: Post-deploy Smoke Test (AI)
+        run: |
+          set -euo pipefail
+
+          BASE_URL="${{ secrets.RELEASE_BASE_URL }}"
+
+          echo "🔎 Smoke 1) /ai/health should return 200"
+          # 1. 헬스체크 (최대 120초 대기)
+          for i in $(seq 1 12); do
+            echo "Attempt $i/12..."
+            if curl -fsS "${BASE_URL}/ai/health" >/dev/null 2>&1; then
+              echo "✅ Health check passed"
+              break
+            fi
+            sleep 10
+          done
+
+          # health 실패하면 종료
+          curl -fsS "${BASE_URL}/ai/health" >/dev/null || {
+            echo "❌ Health check failed"
+            exit 1
+          }
+
+          echo "🔎 Testing batch API..."
+
+          # 2. 실제 API 호출
+          HTTP_CODE=$(curl --max-time 180 -sS -o /tmp/ai_batch_resp.json -w "%{http_code}" \
+            -X POST "${BASE_URL}/ai/api/v1/knowledge/candidates/batch" \
+            -H "Content-Type: application/json" \
+            -H "x-internal-secret: ${{ secrets.INTERNAL_SECRET_KEY }}" \
+            --data '{
+              "items": [
+                {
+                  "id": "history_125",
+                  "keyword": "운영체제",
+                  "rawFeedback": "운영체제"
+                }
+              ]
+            }')
+
+          # 3. HTTP 상태코드 검증 (2xx만 통과)
+          if [ "$HTTP_CODE" -lt 200 ] || [ "$HTTP_CODE" -ge 300 ]; then
+            echo "❌ HTTP $HTTP_CODE"
+            cat /tmp/ai_batch_resp.json
+            exit 1
+          fi
+
+          # 4. 응답 JSON 검증
+          grep -q '"success"[[:space:]]*:[[:space:]]*true' /tmp/ai_batch_resp.json || {
+            echo "❌ success=true not found"
+            cat /tmp/ai_batch_resp.json
+            exit 1
+          }
+
+          echo "🎉 AI smoke tests passed"
+
+  cd-notify-success:
+    needs: cd
+    if: success()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Discord CD success
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_AI }}
+          status: success
+          title: "🟢 AI Deploy Success"
+          content: "AI 서버 릴리즈 서버 배포 완료!"
+          color: 0x00FF00
+
+  cd-notify-failure:
+    needs: cd
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Discord CD failure
+        uses: sarisia/actions-status-discord@v1
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK_AI }}
+          status: failure
+          title: "🔴 AI Deploy Failed"
+          content: "<@&${{ secrets.AI_ROLE_ID }}> AI 릴리즈 서버 배포 실패!"
+          color: 0xFF0000

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -146,6 +146,7 @@ jobs:
               "echo '' >> /home/ubuntu/.env",
               "echo '# ------------- RELEASE --------------' >> /home/ubuntu/.env",
               "aws ssm get-parameters-by-path --path '/MINE/MVP1/AI/ENV/RELEASE' --with-decryption --query 'Parameters[*].[Name,Value]' --output text --region ap-northeast-2 | while IFS=$(printf '\\t') read -r name value; do key=$(basename \"$name\"); echo \"$key=${value:-}\" >> /home/ubuntu/.env; done",
+              "IMAGE_URI=219268921033.dkr.ecr.ap-northeast-2.amazonaws.com/imyme-ai:release-latest",
               "docker pull $IMAGE_URI",
               "docker compose up -d",
               "docker image prune -f"

--- a/ai_server/.dockerignore
+++ b/ai_server/.dockerignore
@@ -1,0 +1,35 @@
+# Git
+.git
+.gitignore
+
+# Python cache
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Test / cache tools
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+.coverage
+htmlcov/
+
+# Logs
+*.log
+
+# IDE
+.vscode/
+.idea/
+
+# OS
+.DS_Store
+
+# Local env files
+.env
+.env.*

--- a/ai_server/Dockerfile
+++ b/ai_server/Dockerfile
@@ -34,6 +34,7 @@ WORKDIR /app
 # torch/sentence-transformers 런타임에서 필요한 라이브러리(특히 libgomp1)
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libgomp1 \
+    curl \
     && rm -rf /var/lib/apt/lists/*
 
 # 빌드 단계에서 생성된 wheel 복사 및 설치

--- a/ai_server/Dockerfile
+++ b/ai_server/Dockerfile
@@ -1,0 +1,52 @@
+# 1) builder: wheels 생성
+FROM python:3.10-slim AS builder
+
+# Python 런타임 기본 최적화
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# Install system dependencies
+# 시스템 의존성 설치
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+
+# Install Python dependencies
+# Python 의존성 설치
+# For ARM64, PyTorch installation might need special handling
+# ARM64의 경우 PyTorch 설치에 특별한 처리가 필요할 수 있음
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip wheel --no-cache-dir --wheel-dir /app/wheels -r requirements.txt
+
+# 2) runtime: 실제 실행 이미지
+FROM python:3.10-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONPATH=/app
+
+WORKDIR /app
+
+# torch/sentence-transformers 런타임에서 필요한 라이브러리(특히 libgomp1)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libgomp1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# 빌드 단계에서 생성된 wheel 복사 및 설치
+COPY --from=builder /app/wheels /wheels
+COPY requirements.txt .
+
+# wheel 폴더만 보고 설치 (인터넷 재다운로드 방지)
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir --no-index --find-links=/wheels -r requirements.txt && \
+    rm -rf /wheels
+
+# 앱 복사
+COPY app/ /app/app/
+
+EXPOSE 8000
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  ai-server:
+    image: 219268921033.dkr.ecr.ap-northeast-2.amazonaws.com/imyme-ai:release-latest
+    container_name: imyme-ai-server
+    ports:
+      - "8000:8000"
+    environment:
+      - PYTHONUNBUFFERED=1
+    env_file:
+      - .env
+    restart: unless-stopped
+    platform: linux/arm64
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 40s
+    networks:
+      - imyme-network
+
+networks:
+  imyme-network:
+    driver: bridge


### PR DESCRIPTION
## 목적
AI 서버의 배포 경로를 Docker 기반 CI/CD로 통합 전환하고, `release → main` 승격 구조를 통해 본배포 전 검증 신뢰도를 높입니다.

## 주요 변경 사항
### 1️⃣ 브랜치 전략 정리
- dev → release → main 구조 적용
- release 브랜치 신설 (운영 동일 환경 검증용)

### 2️⃣ CI/CD Docker 기반 전환
#### RELEASE

- 트리거: release
- 이미지 태그: release-latest + ${{ github.sha }}
- 환경변수 경로:
  - /MINE/MVP1/AI/ENV/COMMON
  - /MINE/MVP1/AI/ENV/RELEASE
- 배포 대상: mine_mvp1_ai_asg
- 스모크 테스트: RELEASE_BASE_URL

#### PROD

- 트리거: main
- 이미지 태그: prod-latest + ${{ github.sha }}
- 환경변수 경로: 
  - /MINE/MVP1/AI/ENV/COMMON
  - /MINE/MVP1/AI/ENV/PROD
- 배포 대상: mine_mvp1_ai_asg-prod
- 스모크 테스트: PROD_BASE_URL

### 3️⃣ 인프라 변경
- Docker multi-stage build 적용
- .dockerignore 정리
- curl 포함 (healthcheck 대응)
- ALB Idle timeout 180초로 조정
- SSM + ASG 기반 롤링 배포

## 기대 효과
- 운영과 동일한 release 환경에서 사전 검증 가능
- Python/라이브러리 의존성 고정으로 환경 차이 제거
- release / prod 배포 경로 분리로 리스크 감소