### PR TITLE
feat[#40]: AI 서버 성능 지표 측정을 위한 메트릭 expose 구현

### DIFF
--- a/ai_server/app/core/metrics.py
+++ b/ai_server/app/core/metrics.py
@@ -1,0 +1,154 @@
+"""
+In-process metrics collector for ai_server.
+
+Collects:
+  - API E2E latency  (sliding window, last MAX_SAMPLES requests)
+  - RPS              (timestamp deque, 1 s / 60 s windows)
+  - CPU / Memory     (psutil process)
+  - Network I/O      (psutil net_io_counters)
+
+Thread-safe via threading.Lock.
+Python 3.10 compatible.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections import deque
+from typing import Any
+
+import psutil
+
+# ─── tunables ────────────────────────────────────────────────────────────────
+MAX_SAMPLES = 2_000          # latency ring buffer size
+TIMESTAMP_WINDOW = 60.0      # seconds kept in the RPS deque
+# ─────────────────────────────────────────────────────────────────────────────
+
+_lock = threading.Lock()
+
+# latency samples (ms), newest at right
+_latency_deque: deque[float] = deque(maxlen=MAX_SAMPLES)
+
+# request finish-timestamps (monotonic), kept only within TIMESTAMP_WINDOW
+_ts_deque: deque[float] = deque()
+
+# cumulative counters
+_requests_total: int = 0
+_status_counts: dict[str, int] = {}
+
+# psutil handles (created once)
+_process = psutil.Process()
+
+
+# ─── public API ──────────────────────────────────────────────────────────────
+
+def record_request(latency_ms: float, status_code: int) -> None:
+    """Call this after each HTTP response is sent."""
+    now = time.monotonic()
+    status_key = str(status_code)
+
+    with _lock:
+        _latency_deque.append(latency_ms)
+
+        # evict old timestamps
+        cutoff = now - TIMESTAMP_WINDOW
+        while _ts_deque and _ts_deque[0] < cutoff:
+            _ts_deque.popleft()
+        _ts_deque.append(now)
+
+        global _requests_total
+        _requests_total += 1
+        _status_counts[status_key] = _status_counts.get(status_key, 0) + 1
+
+
+def get_metrics() -> dict[str, Any]:
+    """Return a point-in-time snapshot. Never raises."""
+    try:
+        return _build_metrics()
+    except Exception:
+        return {"error": "metrics collection failed"}
+
+
+# ─── internals ───────────────────────────────────────────────────────────────
+
+def _percentile(sorted_data: list[float], pct: float) -> float:
+    """Return the pct-th percentile of a pre-sorted list (0–100)."""
+    n = len(sorted_data)
+    if n == 0:
+        return 0.0
+    idx = (pct / 100.0) * (n - 1)
+    lo = int(idx)
+    hi = min(lo + 1, n - 1)
+    frac = idx - lo
+    return sorted_data[lo] * (1 - frac) + sorted_data[hi] * frac
+
+
+def _build_metrics() -> dict[str, Any]:
+    now = time.monotonic()
+
+    with _lock:
+        latency_snapshot = list(_latency_deque)
+        ts_snapshot = list(_ts_deque)
+        requests_total = _requests_total
+        status_counts = dict(_status_counts)
+
+    # ── latency ──────────────────────────────────────────────────────────────
+    if latency_snapshot:
+        sorted_lat = sorted(latency_snapshot)
+        avg_ms = sum(sorted_lat) / len(sorted_lat)
+        p95_ms = _percentile(sorted_lat, 95)
+        p99_ms = _percentile(sorted_lat, 99)
+    else:
+        avg_ms = p95_ms = p99_ms = 0.0
+    sample_size = len(latency_snapshot)
+
+    # ── throughput ───────────────────────────────────────────────────────────
+    cutoff_1s = now - 1.0
+    cutoff_60s = now - TIMESTAMP_WINDOW
+    rps_1s = sum(1 for t in ts_snapshot if t >= cutoff_1s)
+    requests_last_60s = sum(1 for t in ts_snapshot if t >= cutoff_60s)
+    rps_60s_avg = round(requests_last_60s / TIMESTAMP_WINDOW, 4)
+
+    # ── resource utilization ─────────────────────────────────────────────────
+    try:
+        cpu_pct = _process.cpu_percent(interval=None)
+        mem = _process.memory_info()
+        mem_rss = mem.rss
+        mem_vms = mem.vms
+    except Exception:
+        cpu_pct = mem_rss = mem_vms = 0
+
+    try:
+        net = psutil.net_io_counters()
+        net_sent = net.bytes_sent
+        net_recv = net.bytes_recv
+        net_pkts_sent = net.packets_sent
+        net_pkts_recv = net.packets_recv
+    except Exception:
+        net_sent = net_recv = net_pkts_sent = net_pkts_recv = 0
+
+    return {
+        "latency": {
+            "avg_ms": round(avg_ms, 3),
+            "p95_ms": round(p95_ms, 3),
+            "p99_ms": round(p99_ms, 3),
+            "sample_size": sample_size,
+        },
+        "throughput": {
+            "rps_1s": rps_1s,
+            "rps_60s_avg": rps_60s_avg,
+            "requests_total": requests_total,
+            "requests_last_60s": requests_last_60s,
+            "status_counts": status_counts,
+        },
+        "resource_utilization": {
+            "cpu_percent_process": cpu_pct,
+            "memory_rss_bytes": mem_rss,
+            "memory_vms_bytes": mem_vms,
+            "network_io_bytes_sent": net_sent,
+            "network_io_bytes_recv": net_recv,
+            "network_packets_sent": net_pkts_sent,
+            "network_packets_recv": net_pkts_recv,
+        },
+    }

--- a/ai_server/app/core/metrics.py
+++ b/ai_server/app/core/metrics.py
@@ -21,8 +21,8 @@ from typing import Any
 import psutil
 
 # ─── tunables ────────────────────────────────────────────────────────────────
-MAX_SAMPLES = 2_000          # latency ring buffer size
-TIMESTAMP_WINDOW = 60.0      # seconds kept in the RPS deque
+MAX_SAMPLES = 2_000  # latency ring buffer size
+TIMESTAMP_WINDOW = 60.0  # seconds kept in the RPS deque
 # ─────────────────────────────────────────────────────────────────────────────
 
 _lock = threading.Lock()
@@ -42,6 +42,7 @@ _process = psutil.Process()
 
 
 # ─── public API ──────────────────────────────────────────────────────────────
+
 
 def record_request(latency_ms: float, status_code: int) -> None:
     """Call this after each HTTP response is sent."""
@@ -71,6 +72,7 @@ def get_metrics() -> dict[str, Any]:
 
 
 # ─── internals ───────────────────────────────────────────────────────────────
+
 
 def _percentile(sorted_data: list[float], pct: float) -> float:
     """Return the pct-th percentile of a pre-sorted list (0–100)."""

--- a/ai_server/app/main.py
+++ b/ai_server/app/main.py
@@ -1,3 +1,5 @@
+import time
+
 from fastapi import FastAPI, Request, Security
 from fastapi.responses import JSONResponse
 from fastapi.security import APIKeyHeader
@@ -6,6 +8,7 @@ from app.core.config import settings
 from app.core.exception_handlers import add_exception_handlers
 from app.core.errors import ErrorCode
 from app.schemas.common import create_error_response
+from app.core import metrics
 import logging
 
 # Configure logging
@@ -39,6 +42,7 @@ async def verify_internal_secret(request: Request, call_next):
 
     if path in [
         "/health",
+        "/metrics",
         "/docs",
         "/openapi.json",
         "/",
@@ -65,6 +69,19 @@ async def verify_internal_secret(request: Request, call_next):
     return response
 
 
+# ── Latency middleware (runs after auth middleware) ───────────────────────────
+@app.middleware("http")
+async def record_latency(request: Request, call_next):
+    start = time.perf_counter()
+    response = await call_next(request)
+    elapsed_ms = (time.perf_counter() - start) * 1000.0
+    try:
+        metrics.record_request(elapsed_ms, response.status_code)
+    except Exception:
+        pass  # never let metrics break the response
+    return response
+
+
 # Include API routers
 # API 라우터 포함
 app.include_router(api_router, prefix=settings.API_V1_STR)
@@ -83,6 +100,14 @@ def health_check():
     Load Balancer Health Check
     """
     return {"status": "ok"}
+
+
+@app.get("/metrics")
+def get_metrics():
+    """
+    In-process metrics: latency, throughput, resource utilization.
+    """
+    return metrics.get_metrics()
 
 
 if __name__ == "__main__":

--- a/ai_server/requirements.txt
+++ b/ai_server/requirements.txt
@@ -1,4 +1,5 @@
 fastapi>=0.110.0
+psutil>=5.9.0
 uvicorn>=0.30.0
 python-multipart>=0.0.9
 requests>=2.31.0


### PR DESCRIPTION
## 🔗 관련 이슈

closes #40

## ❗️ 필요성

AI 서버의 운영 가시성이 전혀 없는 상태로, 장애 발생 시 latency·RPS·리소스 사용량을 즉시 파악할 방법이 없었습니다.
외부 모니터링 솔루션(Prometheus 등) 도입 전, 앱 단독으로 성능 지표를 조회할 수 있는 엔드포인트가 필요합니다.

## 📄 내용

**수집 메트릭**

| 분류 | 항목 |
|---|---|
| Latency | avg_ms / p95_ms / p99_ms / sample_size |
| Throughput | rps_1s / rps_60s_avg / requests_total / requests_last_60s / status_counts |
| Resource | cpu_percent_process / memory_rss_bytes / memory_vms_bytes / network_io_bytes_sent / network_io_bytes_recv / network_packets_sent / network_packets_recv |

## ⬅️ 변경 전

- `/metrics` 엔드포인트 없음
- 서버 latency, RPS, CPU/Memory, Network I/O 확인 불가
- 성능 이상 감지를 위한 수단 없음

## ✅ 변경 후

- `GET /metrics` 로 실시간 성능 지표 JSON 조회 가능
- 기존 API 엔드포인트 계약 변경 없음, `stt_server` 무수정

## 💁 결론

로컬 Docker 환경 (`/health` 20회 부하 후) 실측값:

| 지표 | 값 |
|---|---|
| avg latency | 1.917 ms |
| p95 latency | 2.641 ms |
| p99 latency | 14.521 ms |
| requests_total | 23 |
| memory_rss | ~419 MB (torch 포함) |
| network_io | 정상 수집 확인 |