### PR TITLE
Fix/pvp schema sync

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -434,3 +434,130 @@ Worker에서 에러를 덮어두지 않고, 예외를 명시적으로 던져(Rai
 - 일시적 장애 발생 시 최대 3번(10초)까지 인프라 복원력을 확보하여 **억울한 FAIL 응답 감소**.
 - 에러 원본 페이로드가 파괴되지 않고 DLQ에 보존되어 **개발자 디버깅(Replay) 편의성 극대화**.
 
+
+## 17. LLM-as-a-Judge 위치 편향(Positional Bias) 및 Logprobs 추출 이슈
+
+### 17.1. 문제 상황 (Problem)
+- **증상 1 (위치 편향)**: 두 개의 답변(A, B)을 비교 평가하는 프롬프트에서, `gemini-2.5-flash` 모델이 **실제 품질과 무관하게 항상 두 번째(B) 혹은 첫 번째(A) 위치의 답변을 승자로 선택**하는 극단적인 위치 편향(Positional Bias) 현상이 확인됨.
+- **증상 2 (Logprobs 추출 실패)**: 편향을 수학적으로 교정하기 위해 PAIRS(Pairwise-preference Search) 기법을 도입하여 토큰 확률(logprobs)을 추출하려 했으나, 일반 API Key 환경에서는 `Logprobs is not enabled` 에러가 발생.
+- **증상 3 (Thinking 토큰 충돌)**: Vertex AI로 전환 후, 출력 토큰을 1개로 제한(`max_output_tokens=1`)하여 정답("1" 또는 "2")의 확률만 추출하려 했으나, 최신 Flash 모델들의 사전 내부 추론(Thinking) 기능이 발동되어 첫 토큰으로 `<thought>` 등을 출력하다가 잘려버림. 이로 인해 결과 텍스트가 빈 문자열(`EMPTY`)로 반환되고 필요한 logprobs를 얻지 못함.
+
+### 17.2. 원인 분석 (Root Cause)
+1. **API 권한**: Gemini 모델의 `logprobs` 기능은 철저히 **Google Cloud Vertex AI** 환경 전용으로 제한되어 있었음.
+2. **디코딩(Decoding) 간섭**: `max_output_tokens=1` 방식은 모델의 생성 "길이"만 자를 뿐, 모델이 어떤 단어를 선택할지(확률 공간)는 제어하지 못함. "Thinking" 모델들은 본능적으로 추론 토큰을 먼저 생성하려 하므로, 길이가 1로 제한된 상태에서는 정답 토큰("1", "2")에 도달하기 전에 응답이 강제 종료됨.
+
+### 17.3. 해결 방안 (Solution)
+**Constrained Decoding (제약 기반 디코딩) 및 Vertex AI 도입**
+
+1. **Vertex AI 클라이언트로 마이그레이션**:
+   - `google.genai` SDK 사용 및 `genai.Client(vertexai=True, project=..., location=...)` 로 초기화.
+   - 호환성을 위해 `gcloud auth application-default login`을 통해 로컬 인증 자격 증명(ADC) 설정.
+
+2. **Enum Schema를 통한 출력 제약 (Constrained Decoding)**:
+   - `max_output_tokens=1` 옵션을 제거하고, **공식 권장 방식인 `text/x.enum` 스키마 제약**으로 전면 교체.
+   ```python
+   # 수정 후: 스키마를 통해 출력 풀(Pool)을 아예 "1", "2"로 물리적 격리
+   config = types.GenerateContentConfig(
+       response_mime_type="text/x.enum",
+       response_schema={"type": "STRING", "enum": ["1", "2"]},
+       response_logprobs=True,
+       logprobs=5
+   )
+   ```
+   - **원리**: 모델의 예측 확률 공간 자체를 `["1", "2"]` 두 단어로 강제 제한함. 모델은 내부 추론(`<thought>`)을 하고 싶어도 해당 토큰이 허용되지 않으므로, 추론 과정을 건너뛰고 즉각적으로 "1" 또는 "2"에 대한 Logprob을 계산하여 반환하게 됨.
+
+### 17.4. 결과 및 효과 (Results)
+- **Logprob 정상 추출**: `gemini-3-flash-preview` 등 최신 Thinking 모델에서도 에러나 빈 응답 없이 "1"과 "2"의 토큰 확률 데이터를 안정적으로 얻어냄.
+- **편향의 원천 차단 (Surprise Finding)**: Enum Schema로 디코딩을 강하게 제약한 결과, 원래 순서와 무관하게 2번을 뽑던 편향 모델이 **Raw 텍스트 판정 단계에서부터 편향 없이 항상 더 나은 정답을(100%) 고르는 부수적인 효과(Debiasing Effect)**까지 달성함.
+- **최종 보정**: 추출된 Logprobs를 Softmax 정규화 및 양방향[A-B, B-A] 평균 교정(Bradley-Terry Model)에 사용하여, $\approx 99.7\%$의 매우 안정적이고 신뢰도 높은 확신 점수(Confidence Score)를 확보.
+
+
+## 18. RabbitMQ 큐 미생성 및 연결 실패 (Docker 네트워크 이슈)
+
+### 18.1. 문제 상황 (Problem)
+- **증상 1**: AI 서버 배포(CD) 후 RabbitMQ Management UI(`15671`)에 큐가 0개로 표시됨.
+- **증상 2**: AI 서버 로그에서 `CONNECTION_FORCED - broker forced connection closure with reason 'shutdown'` 에러 발생 후, `[Errno 111] Connect call failed ('127.0.0.1', 5672)` 에러가 5초 간격으로 무한 반복.
+    ```
+    ERROR:aiormq.connection:Unexpected connection close from remote
+      "amqp://admin:******@localhost:5672/",
+      Connection.Close(reply_code=320,
+      reply_text="CONNECTION_FORCED - broker forced connection closure
+                   with reason 'shutdown'")
+
+    ERROR:aiormq.connection:error when creating transport:
+      <AMQPConnectionError: (111, "Connect call failed ('127.0.0.1', 5672)")>
+    ```
+- **증상 3**: RabbitMQ Management UI 접속 시 `15672`는 흰 화면(접속 불가), `15671`에서만 접속 가능하나 큐가 비어있음.
+
+### 18.2. 원인 분석 (Root Cause)
+
+1. **Docker 네트워크 격리**: RabbitMQ 컨테이너의 포트가 `127.0.0.1:5672->5672/tcp`로 바인딩되어 있어 호스트 루프백에서만 접속 가능. AI 서버가 도커 컨테이너 내부에서 `localhost`를 호출하면 자기 자신(AI 컨테이너)을 가리키게 됨.
+2. **컨테이너 재시작 타이밍**: RabbitMQ 도커 컨테이너를 재시작하면서 기존 연결이 `CONNECTION_FORCED`로 강제 종료되었고, 재시작 완료 전에 AI 서버가 재접속을 시도하여 `Connection Refused` 발생.
+3. **레거시 프로세스 잔존**: AI 서버가 Docker 배포본이 아닌 우분투 OS에 직접 설치된 구버전 프로세스(PM2)로 실행되고 있었으며, `/home/ubuntu/mine/ai/shared/.env` 파일을 참조하고 있었음.
+
+### 18.3. 해결 방안 (Solution)
+
+1. **인프라 현황 파악**:
+    ```bash
+    sudo docker ps | grep rabbitmq  # → dev-rabbitmq healthy 확인
+    sudo netstat -tulpn | grep 5672  # → docker-proxy 확인
+    ```
+2. **실제 `.env` 파일 위치 특정 및 수정**: `/home/ubuntu/mine/ai/shared/.env`의 `RABBITMQ_URL`에서 `localhost`를 Docker 게이트웨이 IP(`172.17.0.1`) 또는 컨테이너 이름(`dev-rabbitmq`)으로 변경.
+3. **서비스 시작 순서 보장**: RabbitMQ 컨테이너가 `healthy` 상태가 된 후 AI 서버를 재시작.
+
+### 18.4. 교훈 (Lessons Learned)
+> Docker 환경에서 `localhost`는 "자기 자신의 컨테이너 내부"를 가리킨다. 호스트 OS에서 직접 실행되는 프로세스와 Docker 컨테이너 간 통신 시에는 반드시 Docker 네트워크 이름이나 호스트 게이트웨이 IP를 사용해야 한다.
+
+
+## 19. Pydantic 스키마 불일치로 인한 STT 메시지 전량 Reject
+
+### 19.1. 문제 상황 (Problem)
+- **증상**: RabbitMQ 연결이 정상화된 후, 메인 서버(Spring Boot)가 `pvp.stt.request` 큐로 보낸 메시지가 AI 서버의 Pydantic 검증 단계에서 전량 Reject 처리됨. 3회 재시도 후 DLQ로 이동.
+    ```
+    ERROR: 3 validation errors for STTRequest
+    match_id
+      Field required [input_value={'room_id': 27, 'user_id': 1, ...}]
+    user_id
+      Input should be a valid string [input_value=1, input_type=int]
+    file_url
+      Field required [input_value={'room_id': 27, 'user_id': 1, ...}]
+    ```
+
+### 19.2. 원인 분석 (Root Cause)
+AI 서버의 Pydantic 스키마(`pvp_schema.py`)와 메인 서버(Spring Boot)의 DTO 정의가 서로 다른 버전의 규격서를 참조하고 있었음. 양측 간 최종 스키마 동기화(Sync-up) 과정이 누락되어, 운영 환경에서 처음으로 통신할 때 불일치가 발견됨.
+
+| 필드 | AI 서버 (기존 코드) | 메인 서버 (실제 전송) | 불일치 |
+|------|---------------------|----------------------|--------|
+| 매치/방 ID | `match_id: str` | `room_id: int` | ❌ 키 이름 + 타입 |
+| 사용자 ID | `user_id: str` | `user_id: int` | ❌ 타입 |
+| 오디오 URL | `file_url: str` | `audio_url: str` | ❌ 키 이름 |
+| 모범 답안 | `modelAnswer: str` | `model_answer: str` | ❌ camelCase vs snake_case |
+
+### 19.3. 해결 방안 (Solution)
+메인 서버의 실제 전송 형식을 기준으로 AI 서버 코드를 전면 리팩토링 (9개 파일 수정).
+
+| # | 파일 | 변경 내용 |
+|---|------|----------|
+| 1 | `app/schemas/pvp_schema.py` | Pydantic 모델 전면 수정 (필드명, 타입, 구조) |
+| 2 | `app/workers/stt_worker.py` | `room_id`, `audio_url` 참조 변경 |
+| 3 | `app/workers/feedback_worker.py` | `room_id`, `feedbacks` 배열 구조 반영 |
+| 4 | `app/services/rabbitmq_service.py` | FAIL 응답 `room_id` 반영, `feedbacks:null` 추가 |
+| 5 | `app/services/pvp_feedback_service.py` | 반환 구조 배열화, 필드명 전면 교체 |
+| 6-9 | `tests/services/test_*.py` (4개) | 테스트 데이터 & assertion 수정 |
+
+**주요 스키마 변경 사항**:
+- `match_id` (str) → **`room_id` (int)**
+- `user_id` (str) → **`user_id` (int)**
+- `file_url` (str) → **`audio_url` (str)**
+- `modelAnswer` → **`model_answer`** (snake_case 통일)
+- Feedback Response: `feedback` (객체 `{user_A, user_B}`) → **`feedbacks` (배열 `[{...}, {...}]`)**
+- `summarize` → **`summary`**, `keyword` → **`keywords`**, `personalized` → **`personalized_feedback`**
+
+### 19.4. 검증 결과 (Verification)
+```
+======================= 40 passed, 6 warnings in 10.63s ========================
+```
+전체 40개 테스트(단위 + 통합) 100% 통과 확인.
+
+### 19.5. 교훈 (Lessons Learned)
+> 마이크로서비스 간 비동기 메시징에서 **"스키마 불일치"는 런타임에서야 발견되는 가장 흔하고 치명적인 버그**이다. `pvp_mq_schema.md`를 단일 진실 공급원(SSOT)으로 확정하고, 스키마 변경 시 반드시 양측(BE/AI) 리뷰를 거쳐 머지하는 프로세스를 도입해야 한다.

--- a/ai_server/app/schemas/pvp_schema.py
+++ b/ai_server/app/schemas/pvp_schema.py
@@ -2,7 +2,7 @@
 PvP Mode Message Payload Schemas.
 PvP 모드 RabbitMQ 메시지 페이로드 스키마 정의.
 
-pvp_spec.md 문서의 큐 규격에 맞춰 Request/Response 모델을 정의합니다.
+pvp_mq_schema.md 문서의 큐 규격에 맞춰 Request/Response 모델을 정의합니다.
 """
 
 from pydantic import BaseModel, Field
@@ -21,9 +21,9 @@ class STTRequest(BaseModel):
     S3 음성 파일 URL을 받아 텍스트로 변환을 요청합니다.
     """
 
-    match_id: str = Field(..., description="매치 ID (Pass-through)")
-    user_id: str = Field(..., description="사용자 ID (Pass-through)")
-    file_url: str = Field(..., description="S3 오디오 파일 URL")
+    room_id: int = Field(..., description="방 ID (Pass-through)")
+    user_id: int = Field(..., description="사용자 ID (Pass-through)")
+    audio_url: str = Field(..., description="S3 오디오 파일 URL")
     timestamp: int = Field(..., description="요청 시간 (Unix timestamp)")
 
 
@@ -33,8 +33,8 @@ class STTResponse(BaseModel):
     STT 변환 결과를 반환합니다.
     """
 
-    match_id: str = Field(..., description="매치 ID (Pass-through)")
-    user_id: str = Field(..., description="사용자 ID (Pass-through)")
+    room_id: int = Field(..., description="방 ID (Pass-through)")
+    user_id: int = Field(..., description="사용자 ID (Pass-through)")
     status: str = Field(..., description="처리 상태 (SUCCESS / FAIL)")
     stt_text: Optional[str] = Field(None, description="변환된 텍스트")
     error: Optional[str] = Field(None, description="실패 시 에러 메시지")
@@ -51,7 +51,7 @@ class PvpUserData(BaseModel):
     PvP 대결에 참여하는 개별 사용자 데이터.
     """
 
-    user_id: str = Field(..., description="사용자 ID")
+    user_id: int = Field(..., description="사용자 ID")
     user_text: str = Field(..., description="사용자의 STT 변환 텍스트")
 
 
@@ -61,7 +61,7 @@ class FeedbackCriteria(BaseModel):
     """
 
     keyword: str = Field(..., description="핵심 키워드")
-    modelAnswer: str = Field(..., description="모범 답안")
+    model_answer: str = Field(..., description="모범 답안")
 
 
 class FeedbackRequest(BaseModel):
@@ -70,7 +70,7 @@ class FeedbackRequest(BaseModel):
     2명의 사용자 STT 결과를 취합하여 비교 피드백을 요청합니다.
     """
 
-    match_id: str = Field(..., description="매치 ID")
+    room_id: int = Field(..., description="방 ID")
     criteria: FeedbackCriteria = Field(..., description="채점 기준")
     users: List[PvpUserData] = Field(
         ..., min_length=2, max_length=2, description="2명의 사용자 데이터"
@@ -81,26 +81,15 @@ class FeedbackRequest(BaseModel):
 class PvpUserFeedback(BaseModel):
     """
     개별 사용자에 대한 PvP 비교 피드백 상세.
-    Solo 모드와 동일한 JSON 구조 + score 필드.
     """
 
-    user_id: str = Field(..., description="사용자 ID")
+    user_id: int = Field(..., description="사용자 ID")
     score: int = Field(..., ge=0, le=100, description="종합 점수 (0-100)")
-    summarize: str = Field(..., description="이해도 요약 (한 문장)")
-    keyword: List[str] = Field(..., description="포함/누락 키워드 리스트")
+    summary: str = Field(..., description="이해도 요약 (한 문장)")
+    keywords: List[str] = Field(..., description="포함/누락 키워드 리스트")
     facts: str = Field(..., description="사실 관계 확인")
     understanding: str = Field(..., description="이해 깊이 평가")
-    personalized: str = Field(..., description="PvP 전략 기반 비교 피드백")
-
-
-class PvpFeedbackResult(BaseModel):
-    """
-    PvP 비교 피드백 전체 결과.
-    각 사용자별 피드백과 공통 피드백을 포함합니다.
-    """
-
-    user_A: PvpUserFeedback = Field(..., description="사용자 A 피드백")
-    user_B: PvpUserFeedback = Field(..., description="사용자 B 피드백")
+    personalized_feedback: str = Field(..., description="PvP 전략 기반 비교 피드백")
 
 
 class FeedbackResponse(BaseModel):
@@ -109,7 +98,7 @@ class FeedbackResponse(BaseModel):
     PvP 비교 분석 피드백 결과를 반환합니다.
     """
 
-    match_id: str = Field(..., description="매치 ID")
+    room_id: int = Field(..., description="방 ID")
     status: str = Field(..., description="처리 상태 (SUCCESS / FAIL)")
-    feedback: Optional[PvpFeedbackResult] = Field(None, description="비교 피드백 결과")
+    feedbacks: Optional[List[PvpUserFeedback]] = Field(None, description="비교 피드백 결과 배열")
     error: Optional[str] = Field(None, description="실패 시 에러 메시지")

--- a/ai_server/app/schemas/pvp_schema.py
+++ b/ai_server/app/schemas/pvp_schema.py
@@ -100,5 +100,7 @@ class FeedbackResponse(BaseModel):
 
     room_id: int = Field(..., description="방 ID")
     status: str = Field(..., description="처리 상태 (SUCCESS / FAIL)")
-    feedbacks: Optional[List[PvpUserFeedback]] = Field(None, description="비교 피드백 결과 배열")
+    feedbacks: Optional[List[PvpUserFeedback]] = Field(
+        None, description="비교 피드백 결과 배열"
+    )
     error: Optional[str] = Field(None, description="실패 시 에러 메시지")

--- a/ai_server/app/services/pvp_feedback_service.py
+++ b/ai_server/app/services/pvp_feedback_service.py
@@ -59,15 +59,15 @@ class PvpFeedbackService:
         """
         2명의 사용자 텍스트를 비교 분석하여 PvP 피드백을 생성합니다.
 
-        출력 JSON 구조는 Solo 모드와 동일합니다:
-        {summarize, keyword, facts, understanding, personalized} (유저별)
+        출력 JSON 구조는 배열 형태입니다:
+        [{summary, keywords, facts, understanding, personalized_feedback}, ...] (유저별)
 
         Args:
-            criteria: 채점 기준 (keyword, modelAnswer)
+            criteria: 채점 기준 (keyword, model_answer)
             users: 2명의 사용자 데이터 리스트 [{user_id, user_text}, ...]
 
         Returns:
-            PvP 비교 피드백 결과 딕셔너리 (user_A, user_B 키 포함)
+            PvP 비교 피드백 결과 리스트 (유저별 딕셔너리 배열)
         """
         user_a = users[0]
         user_b = users[1]
@@ -85,26 +85,26 @@ class PvpFeedbackService:
                 f"Returning mutual forfeit (draw) response."
             )
             draw_msg = "두 분 모두 답변 내용이 부족하여 승부를 가릴 수 없습니다."
-            return {
-                "user_A": {
+            return [
+                {
                     "user_id": user_a["user_id"],
                     "score": 0,
-                    "summarize": draw_msg,
-                    "keyword": ["포함된 키워드: 없음", "누락된 키워드: 전체"],
+                    "summary": draw_msg,
+                    "keywords": ["포함된 키워드: 없음", "누락된 키워드: 전체"],
                     "facts": draw_msg,
                     "understanding": draw_msg,
-                    "personalized": draw_msg,
+                    "personalized_feedback": draw_msg,
                 },
-                "user_B": {
+                {
                     "user_id": user_b["user_id"],
                     "score": 0,
-                    "summarize": draw_msg,
-                    "keyword": ["포함된 키워드: 없음", "누락된 키워드: 전체"],
+                    "summary": draw_msg,
+                    "keywords": ["포함된 키워드: 없음", "누락된 키워드: 전체"],
                     "facts": draw_msg,
                     "understanding": draw_msg,
-                    "personalized": draw_msg,
+                    "personalized_feedback": draw_msg,
                 },
-            }
+            ]
 
         # ===== Case B: 한쪽만 기권 (부전승) =====
         if a_short:
@@ -148,6 +148,19 @@ class PvpFeedbackService:
 
         # CoT reasoning 필드는 내부 추론용이므로 최종 응답에서 제거
         result.pop("reasoning", None)
+
+        # Gemini 응답이 {user_A, user_B} 객체 형태로 올 경우 배열로 변환
+        if isinstance(result, dict):
+            feedbacks = []
+            for key in ["user_A", "user_B"]:
+                if key in result:
+                    feedbacks.append(result[key])
+            if feedbacks:
+                return feedbacks
+
+        # 이미 배열 형태라면 그대로 반환
+        if isinstance(result, list):
+            return result
 
         return result
 

--- a/ai_server/app/services/rabbitmq_service.py
+++ b/ai_server/app/services/rabbitmq_service.py
@@ -162,7 +162,7 @@ class RabbitMQService:
                 body = json.loads(message.body.decode())
                 logger.info(
                     f"Consumed from '{queue_name}' (retry: {retry_count}): "
-                    f"match_id={body.get('match_id', 'N/A')}"
+                    f"room_id={body.get('room_id', 'N/A')}"
                 )
 
                 # Execute business logic callback (worker handler)
@@ -208,7 +208,7 @@ class RabbitMQService:
                         try:
                             original_body = json.loads(message.body.decode())
                             fail_response = {
-                                "match_id": original_body.get("match_id", "unknown"),
+                                "room_id": original_body.get("room_id", 0),
                                 "status": "FAIL",
                                 "error": (
                                     f"Message failed after {MAX_RETRY_COUNT} "
@@ -218,10 +218,13 @@ class RabbitMQService:
                             # Include user_id for STT responses
                             if "user_id" in original_body:
                                 fail_response["user_id"] = original_body["user_id"]
+                            # Include feedbacks:null for Feedback responses
+                            if "users" in original_body:
+                                fail_response["feedbacks"] = None
                             await self.publish(response_queue, fail_response)
                             logger.info(
                                 f"Published FAIL response to '{response_queue}' "
-                                f"for match={fail_response['match_id']}"
+                                f"for room={fail_response['room_id']}"
                             )
                         except Exception as fail_err:
                             logger.error(f"Failed to publish FAIL response: {fail_err}")

--- a/ai_server/app/workers/feedback_worker.py
+++ b/ai_server/app/workers/feedback_worker.py
@@ -26,7 +26,7 @@ from aio_pika.abc import AbstractIncomingMessage
 from app.core.config import settings
 from app.services.rabbitmq_service import rabbitmq_service
 from app.services.pvp_feedback_service import pvp_feedback_service
-from app.schemas.pvp_schema import FeedbackRequest, FeedbackResponse, PvpFeedbackResult
+from app.schemas.pvp_schema import FeedbackRequest, FeedbackResponse, PvpUserFeedback
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +49,7 @@ async def handle_feedback_message(body: dict, message: AbstractIncomingMessage) 
     # 1. Validate payload with Pydantic
     request = FeedbackRequest(**body)
     logger.info(
-        f"[Feedback Worker] Processing match={request.match_id}, "
+        f"[Feedback Worker] Processing room={request.room_id}, "
         f"users={[u.user_id for u in request.users]}"
     )
 
@@ -61,17 +61,18 @@ async def handle_feedback_message(body: dict, message: AbstractIncomingMessage) 
     )
 
     # 3. Build and publish SUCCESS response
+    #    feedback_result is now a list of dicts (one per user)
     response = FeedbackResponse(
-        match_id=request.match_id,
+        room_id=request.room_id,
         status="SUCCESS",
-        feedback=PvpFeedbackResult(**feedback_result),
+        feedbacks=[PvpUserFeedback(**fb) for fb in feedback_result],
     )
 
     await rabbitmq_service.publish(
         settings.FEEDBACK_RESULT_QUEUE, response.model_dump()
     )
 
-    logger.info(f"[Feedback Worker] Completed match={request.match_id}")
+    logger.info(f"[Feedback Worker] Completed room={request.room_id}")
 
     # NOTE: If any exception occurs above, it will propagate to
     # rabbitmq_service.py's on_message handler, which will:

--- a/ai_server/app/workers/stt_worker.py
+++ b/ai_server/app/workers/stt_worker.py
@@ -43,7 +43,7 @@ async def handle_stt_message(body: dict, message: AbstractIncomingMessage) -> No
     # 1. Validate payload with Pydantic
     request = STTRequest(**body)
     logger.info(
-        f"[STT Worker] Processing match={request.match_id}, user={request.user_id}"
+        f"[STT Worker] Processing room={request.room_id}, user={request.user_id}"
     )
 
     # 2. Call RunPod STT
@@ -51,12 +51,12 @@ async def handle_stt_message(body: dict, message: AbstractIncomingMessage) -> No
     # so we delegate it to the thread pool to avoid blocking the event loop
     stt_result = await asyncio.to_thread(
         runpod_client.transcribe_sync,
-        audio_url=request.file_url,
+        audio_url=request.audio_url,
     )
 
     # 3. Build and publish SUCCESS response
     response = STTResponse(
-        match_id=request.match_id,
+        room_id=request.room_id,
         user_id=request.user_id,
         status="SUCCESS",
         stt_text=stt_result.get("text", ""),
@@ -65,7 +65,7 @@ async def handle_stt_message(body: dict, message: AbstractIncomingMessage) -> No
     await rabbitmq_service.publish(settings.STT_RESULT_QUEUE, response.model_dump())
 
     logger.info(
-        f"[STT Worker] Completed match={request.match_id}, user={request.user_id}"
+        f"[STT Worker] Completed room={request.room_id}, user={request.user_id}"
     )
 
     # NOTE: If any exception occurs above, it will propagate to


### PR DESCRIPTION
## 💡 작업 목적 & 배경
- AI 서버와 메인 서버(Spring Boot) 간 RabbitMQ 통신 과정에서 **변수명(match_id ↔ room_id) 및 데이터 타입(str ↔ int) 불일치**로 인해 Pydantic에서 전량 `ValidationError`가 발생하여 메시지가 Reject 되는 이슈가 발견되었습니다.
- 메인(BE) 서버에서 이미 구현되어 쏘고 있는 실제 DTO 객체(JSON 페이로드) 형태를 Single Source of Truth로 삼아, AI 서버의 코드를 전면 리팩토링하여 맞춥니다.

## 🛠️ 주요 변경 사항
1. **스키마 필드명 및 타입 전면 교체 ([app/schemas/pvp_schema.py](cci:7://file:///Users/goorm/dir_ktbai/runpod_stt/4-team-IMYME-ai/ai_server/app/schemas/pvp_schema.py:0:0-0:0))**
   - `match_id(str)` → `room_id(int)`
   - `user_id(str)` → `user_id(int)`
   - `file_url` → `audio_url`
   - `modelAnswer` → `model_answer` (snake_case 통일)
2. **피드백 응답 구조 배열화 ([app/services/pvp_feedback_service.py](cci:7://file:///Users/goorm/dir_ktbai/runpod_stt/4-team-IMYME-ai/ai_server/app/services/pvp_feedback_service.py:0:0-0:0))**
   - 기존의 `{user_A: {...}, user_B: {...}}` 형태의 Object 반환에서 `[{...}, {...}]` 형태의 Array 반환으로 변경.
   - 내부 세부 필드명 변경: `summarize` → `summary`, `keyword` → `keywords`, `personalized` → `personalized_feedback`
3. **Worker 및 RabbitMQ 예외 처리부 갱신**
   - `stt_worker`, `feedback_worker` 모두 새 규격에 맞춰 파싱/조립 로직 수정.
   - 3회 재시도 최종 실패 시 발행되는 강제 `FAIL` 응답(DLQ 라우팅 시점)에도 `room_id` 및 `feedbacks: null` 규격 적용 완료.
4. **테스트 및 장애 보고서 수립**
   - 변경된 규격에 맞게 4개 테스트 파일 전면 수정하여 40개 테스트 모두 100% PASSED 완료.
   - [TROUBLESHOOTING.md](cci:7://file:///Users/goorm/dir_ktbai/runpod_stt/4-team-IMYME-ai/TROUBLESHOOTING.md:0:0-0:0)에 이번 스키마 불일치 이슈 및 RabbitMQ 큐 연결 실패(Docker Network / localhost 이슈) 케이스 정리 추가.

## 🚨 리뷰어 참고 사항 & 테스트 방법
- 단위 및 통합 테스트(`pytest tests/ -v`) 통과 완료했습니다.
- 본 PR 머지 후 배포 시, 메인 서버와 AI 서버 간의 STT 및 Feedback 큐 연동이 정상 궤도에 돌입할 것입니다. (추가적인 BE 코드 수정 불필요)
