### PR TITLE
fix(pvp): sync JSON output schema

### DIFF
--- a/ai_server/app/core/prompts.py
+++ b/ai_server/app/core/prompts.py
@@ -207,26 +207,26 @@ Do NOT wrap the output in markdown code blocks. Output raw JSON only.
   "user_A": {{
     "user_id": "{user_a_id}",
     "score": 0,
-    "summarize": "이 사용자의 이해도와 핵심 포인트를 요약한 한 문장.",
-    "keyword": [
+    "summary": "이 사용자의 이해도와 핵심 포인트를 요약한 한 문장.",
+    "keywords": [
       "포함된 키워드: A, B",
       "누락된 키워드: C"
     ],
     "facts": "사실 관계가 정확하면 '사실 관계 정확함', 아니면 오류 지적.",
     "understanding": "이해 깊이 평가 (단순 암기 vs 내재화).",
-    "personalized": "PvP 전략 기반 비교 피드백. 상대방과의 비교를 반영한 코칭."
+    "personalized_feedback": "PvP 전략 기반 비교 피드백. 상대방과의 비교를 반영한 코칭."
   }},
   "user_B": {{
     "user_id": "{user_b_id}",
     "score": 0,
-    "summarize": "이 사용자의 이해도와 핵심 포인트를 요약한 한 문장.",
-    "keyword": [
+    "summary": "이 사용자의 이해도와 핵심 포인트를 요약한 한 문장.",
+    "keywords": [
       "포함된 키워드: A, B",
       "누락된 키워드: C"
     ],
     "facts": "사실 관계가 정확하면 '사실 관계 정확함', 아니면 오류 지적.",
     "understanding": "이해 깊이 평가 (단순 암기 vs 내재화).",
-    "personalized": "PvP 전략 기반 비교 피드백. 상대방과의 비교를 반영한 코칭."
+    "personalized_feedback": "PvP 전략 기반 비교 피드백. 상대방과의 비교를 반영한 코칭."
   }}
 }}
 """


### PR DESCRIPTION
1. **JSON 출력 스키마 오타 수정 (Missing Error 해결)**
   - 메인 서버 페이로드에 맞춰 Pydantic 스키마를 뱀표기법(snake_case)으로 리팩토링한 변경 사항이, 정작 LLM 프롬프트의 출력 예시에는 반영되지 않아 발생하던 Pydantic `[type=missing]` 검증 에러를 해결했습니다.
   - 프롬프트 JSON의 키값을 `summarize` -> `summary`, `keyword` -> `keywords`, `personalized` -> `personalized_feedback`으로 동기화했습니다.