### PR TITLE
V2: add pvp mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ build/
 
 .log
 .log.*
+
+# Tests
+tests/

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -362,24 +362,27 @@ for (EvaluationDecision decision : evalResult.results()) {
 user_text: str = Field(..., alias="userText", ...)
 ```
 
-### 13.4. 안전성 분석 (Safety Analysis)
-#### ✅ 안전한 이유: Defense-in-Depth (다층 방어)
-빈 문자열이 스키마를 통과하더라도, 서비스 레이어에서 안전하게 처리됨:
+## 14. STT Hallucination 및 무음 처리 개선
 
-| 단계 | 위치 | 동작 |
-|------|------|------|
-| ① API Layer | `endpoints/solo.py` | 빈 문자열 수신 → 202 Accepted (즉시 접수) |
-| ② Background Task | `analysis_service.py` (Line 43) | `len(user_text.strip()) < 5` 체크 → LLM 호출 **건너뜀** |
-| ③ Result | `task_store` | `COMPLETED` 상태로 0점 + 안내 피드백 저장 |
+### 14.1. 문제 상황 (Issue)
+- **증상**: 오디오의 무음 구간이나 잡음 구간에서 "MBC 뉴스", "시청해 주셔서 감사합니다" 등의 뜬금없는 텍스트(Hallucination)가 생성됨.
+- **원인**: Whisper 모델의 특성상 침묵 구간에서 언어 모델의 확률 분포가 높은 상용구(훈련 데이터 편향)를 생성하려는 경향이 있음.
 
-- **Main Server 안정성 확보**: 이제 Main Server는 예외 상황(빈 텍스트)에서도 정상적인 분석 완료 응답을 받을 수 있어 무한 대기 문제가 해결됨.
-- **LLM 비용 절감**: 5글자 미만은 API 호출 없이 처리됨.
-- **예외 처리 간소화**: Main Server가 별도의 400 에러 핸들링 로직을 복잡하게 구현할 필요 없이, 표준 프로세스대로 처리 가능.
+### 14.2. 해결 방안 (Solution)
+`4-team-IMYME-ai/stt_server`에 VAD(Voice Activity Detection)를 적용하고, 침묵 감지 로직을 강화하여 무음 구간의 입력을 원천 차단함.
 
-### 13.5. 변경된 API 동작 비교
+#### 적용된 기술적 조치
+1.  **VAD 활성화 (`VAD_FILTER = True`)**
+    *   `faster-whisper` 내장 Silero VAD를 사용하여 음성이 아닌 구간을 전사 전에 필터링.
+2.  **침묵 임계값 강화**
+    *   `min_silence_duration_ms = 500`: 0.5초 이상의 침묵은 과감히 제거 (기본값보다 엄격하게).
+    *   `no_speech_threshold = 0.4`: 모델이 "침묵"이라고 판단하는 확률 기준을 낮춰 민감하게 반응하도록 설정 (기본값 0.6 → 0.4).
+    *   `hallucination_silence_threshold = 2.0`: 2초 이상 침묵으로 판단된 구간에서 텍스트가 나오면 강제로 무시.
+3.  **루프 방지 (`condition_on_previous_text = False`)**
+    *   이전 문맥에 의존하지 않도록 하여, 한번 발생한 환각이 다음 문장으로 이어지는 반복(Loop) 현상 차단.
+4.  **결정론적 추론 (`Temperature = 0.0`)**
+    *   Random Sampling을 방지하여 모델이 불확실한 구간에서 창의적인 오답을 내놓지 못하게 고정.
 
-| 입력 | 변경 전 | 변경 후 |
-|------|---------|---------|
-| `"userText": ""` | ❌ 400 Bad Request → **Main Server 무한 대기** | ✅ 202 Accepted → 0점 완료 (정상 종료) |
-| `"userText": "안녕"` (1~4자) | ✅ 202 Accepted → 0점 | ✅ 202 Accepted → 0점 |
-| `"userText": "프로세스란..."` (5자+) | ✅ 202 Accepted → 정상 분석 | ✅ 202 Accepted → 정상 분석 |
+### 14.3. 변경 파일
+- `4-team-IMYME-ai/stt_server/config.py`: 파라미터 상수 정의.
+- `4-team-IMYME-ai/stt_server/services/inference_service.py`: `model.transcribe()` 호출 시 파라미터 주입 로직 추가.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -472,42 +472,41 @@ Worker에서 에러를 덮어두지 않고, 예외를 명시적으로 던져(Rai
 - **최종 보정**: 추출된 Logprobs를 Softmax 정규화 및 양방향[A-B, B-A] 평균 교정(Bradley-Terry Model)에 사용하여, $\approx 99.7\%$의 매우 안정적이고 신뢰도 높은 확신 점수(Confidence Score)를 확보.
 
 
-## 18. RabbitMQ 큐 미생성 및 연결 실패 (Docker 네트워크 이슈)
+## 18. RabbitMQ 통신 포트 인지 오류(Dev vs Release) 및 시작 순서 불일치
 
 ### 18.1. 문제 상황 (Problem)
-- **증상 1**: AI 서버 배포(CD) 후 RabbitMQ Management UI(`15671`)에 큐가 0개로 표시됨.
-- **증상 2**: AI 서버 로그에서 `CONNECTION_FORCED - broker forced connection closure with reason 'shutdown'` 에러 발생 후, `[Errno 111] Connect call failed ('127.0.0.1', 5672)` 에러가 5초 간격으로 무한 반복.
-    ```
-    ERROR:aiormq.connection:Unexpected connection close from remote
-      "amqp://admin:******@localhost:5672/",
-      Connection.Close(reply_code=320,
-      reply_text="CONNECTION_FORCED - broker forced connection closure
-                   with reason 'shutdown'")
-
-    ERROR:aiormq.connection:error when creating transport:
-      <AMQPConnectionError: (111, "Connect call failed ('127.0.0.1', 5672)")>
-    ```
-- **증상 3**: RabbitMQ Management UI 접속 시 `15672`는 흰 화면(접속 불가), `15671`에서만 접속 가능하나 큐가 비어있음.
+- **증상 1 (15671 포트 큐 0개)**: 로컬 PC 브라우저에서 `15671` 포트로 관리 UI에 접속했으나, 생성되어 있어야 할 큐가 하나도 없는 빈 상태(0개)로 조회됨. 이때 이를 **Dev 서버의 MQ**라고 착각함.
+- **증상 2 (15672 포트 접속 불가)**: 실제 Dev 서버의 MQ인 `15672` 포트로 외부망에서 다이렉트 접속을 시도하면 연결이 원천 차단되어 흰 화면(접속 불가)이 뜸.
+- **증상 3 (CONNECTION_FORCED 에러 루프)**: 동시에 AI 서버 측 로그에서는 `CONNECTION_FORCED` 에러로 기존 연결이 끊어진 직후, `[Errno 111] Connect call failed ('127.0.0.1', 5672)` 에러가 발생하며 수 초 간격으로 엠큐 연결 재시도를 무한 반복함.
 
 ### 18.2. 원인 분석 (Root Cause)
+이 현상들은 **"클라우드 인프라 망 분리(VPC) 특성에 대한 혼동"**과 **"프로세스 기동 타이밍 불일치"**가 복합적으로 얽힌 결과입니다.
 
-1. **Docker 네트워크 격리**: RabbitMQ 컨테이너의 포트가 `127.0.0.1:5672->5672/tcp`로 바인딩되어 있어 호스트 루프백에서만 접속 가능. AI 서버가 도커 컨테이너 내부에서 `localhost`를 호출하면 자기 자신(AI 컨테이너)을 가리키게 됨.
-2. **컨테이너 재시작 타이밍**: RabbitMQ 도커 컨테이너를 재시작하면서 기존 연결이 `CONNECTION_FORCED`로 강제 종료되었고, 재시작 완료 전에 AI 서버가 재접속을 시도하여 `Connection Refused` 발생.
-3. **레거시 프로세스 잔존**: AI 서버가 Docker 배포본이 아닌 우분투 OS에 직접 설치된 구버전 프로세스(PM2)로 실행되고 있었으며, `/home/ubuntu/mine/ai/shared/.env` 파일을 참조하고 있었음.
+1. **증상 1(15671 큐 0개) 원인 (Optical Illusion)**: 
+   - 사용자가 AWS SSM 포트 포워딩(`15671:15671`)을 타고 접속한 타겟(`b-afe39155...mq.ap-northeast-2.on.aws`)은 Dev 서버가 아니라 **운영망(Release) 전용으로 띄워진 Amazon MQ**였습니다.
+   - 현재 테스트 중인 AI 파이썬 프로세스('.env')는 Release Amazon MQ가 아니라, 자기 컴퓨터 내부에 떠있는 **Dev 도커 엠큐(`localhost:5672`)**를 바라보며 큐를 생성하고 있었습니다. 즉, '가' 서버(Dev)에 큐를 만들어두고 '나' 서버(Release 15671) 창을 열어보며 큐가 없다고 착각하는 해프닝이었습니다.
+2. **증상 2(15672 접속 불가) 원인 (Network Isolation)**:
+   - 우분투 서버 호스트에 띄워진 Dev RabbitMQ 도커 컨테이너는 보안을 위해 포트 바인딩이 `127.0.0.1:15672->15672/tcp`로 설정되어 있었습니다. 
+   - 이 설정은 **오직 서버의 호스트 내부(`localhost`)에서만 접근을 허용**하므로, 외부 인터넷 망(개발자의 Mac/PC 브라우저)에서 해당 서버의 공인/사설 IP + 15672 포트로 직접 찔러 들어가는 트래픽은 도커 네트워크/방화벽에 의해 정상적으로 차단된 것입니다.
+3. **증상 3(재연결 무한 루프 에러) 원인 (Startup Order Mismatch)**:
+   - 우분투 OS(호스트)에 네이티브로 직접 실행되는 AI 파이썬 프로세스와, 도커(Docker)로 실행되는 RabbitMQ 컨테이너 간의 **"재시작 순서(Timing) 불일치"**가 핵심 원인입니다.
+   - RabbitMQ 도커가 어떤 이유(재배포 등)로 컨테이너를 재시작하면서 기존 세션을 강제로 날려버려 `CONNECTION_FORCED` 에러가 났습니다.
+   - 직후 AI 서버의 `aio_pika` 라이브러리는 강제로 끊어진 세션을 복구하기 위해 `localhost:5672`를 미친 듯이 찌르며 재연결을 시도했지만, 도커 안의 엠큐가 부팅을 마치고 완전히 준비 상태(`healthy`)가 되기도 전에 시도했으므로 `Connect call failed` (연결 거부)가 난 것입니다.
 
 ### 18.3. 해결 방안 (Solution)
 
-1. **인프라 현황 파악**:
-    ```bash
-    sudo docker ps | grep rabbitmq  # → dev-rabbitmq healthy 확인
-    sudo netstat -tulpn | grep 5672  # → docker-proxy 확인
-    ```
-2. **실제 `.env` 파일 위치 특정 및 수정**: `/home/ubuntu/mine/ai/shared/.env`의 `RABBITMQ_URL`에서 `localhost`를 Docker 게이트웨이 IP(`172.17.0.1`) 또는 컨테이너 이름(`dev-rabbitmq`)으로 변경.
-3. **서비스 시작 순서 보장**: RabbitMQ 컨테이너가 `healthy` 상태가 된 후 AI 서버를 재시작.
-
-### 18.4. 교훈 (Lessons Learned)
-> Docker 환경에서 `localhost`는 "자기 자신의 컨테이너 내부"를 가리킨다. 호스트 OS에서 직접 실행되는 프로세스와 Docker 컨테이너 간 통신 시에는 반드시 Docker 네트워크 이름이나 호스트 게이트웨이 IP를 사용해야 한다.
-
+1. **Dev/Release 엔드포인트 혼동 인지 (15671 관측 오류 해결)**: 
+   - `15671` SSM 터널링은 **Release 환경 모니터링 전용**임을 팀 내 개발자들에게 명확히 인지시킴.
+   - Dev 서버 통신 테스트를 할 때는 반드시 아래 2번 방법을 사용해 도커 내부 엠큐(`15672`)를 모니터링해야 함.
+2. **안전한 Dev 관리 UI 접속 (SSH 터널링)**: 
+   - 도커 컨테이너의 보안 호스트 바인딩(`127.0.0.1:15672`)을 해제해 퍼블릭으로 뚫는 것은 위험합니다. 바인딩을 그대로 유지하되, 개발자의 로컬 PC에서 **SSH 터널링(Port Forwarding)**을 사용하여 캡슐화된 암호 파이프를 뚫어 호스트 내부망으로 우회 접속합니다.
+   ```bash
+   # 로컬 PC 터미널에서 실행 (pem 키가 필요한 경우 -i 옵션 추가)
+   ssh -L 15672:localhost:15672 사용자계정@서버IP주소
+   ```
+   이후 로컬 PC 브라우저에서 `http://localhost:15672` 로 접속하면, 방화벽을 뚫고 도커 내부의 진짜 Dev 큐 구조가 담긴 찐 UI 화면을 안전하게 열람할 수 있습니다.
+3. **서비스 시작 순서 논리적 보장 (Shutdown Error 방지)**: 
+   - **타이밍 제어**: AI 서버 파이썬 프로세스는 항상 **RabbitMQ 도커 컨테이너 상태가 완전히 `healthy`**이거나 최소한 5672 포트가 리스닝(Listening) 상태가 되었을 때 후행적으로 재시작 하도록 **"스타트업 순서(Startup Sequence) 보증 스크립트"**를 도입하여 연결 무한 실패를 방지했습니다.
 
 ## 19. Pydantic 스키마 불일치로 인한 STT 메시지 전량 Reject
 
@@ -553,11 +552,27 @@ AI 서버의 Pydantic 스키마(`pvp_schema.py`)와 메인 서버(Spring Boot)�
 - Feedback Response: `feedback` (객체 `{user_A, user_B}`) → **`feedbacks` (배열 `[{...}, {...}]`)**
 - `summarize` → **`summary`**, `keyword` → **`keywords`**, `personalized` → **`personalized_feedback`**
 
-### 19.4. 검증 결과 (Verification)
-```
-======================= 40 passed, 6 warnings in 10.63s ========================
-```
-전체 40개 테스트(단위 + 통합) 100% 통과 확인.
 
-### 19.5. 교훈 (Lessons Learned)
-> 마이크로서비스 간 비동기 메시징에서 **"스키마 불일치"는 런타임에서야 발견되는 가장 흔하고 치명적인 버그**이다. `pvp_mq_schema.md`를 단일 진실 공급원(SSOT)으로 확정하고, 스키마 변경 시 반드시 양측(BE/AI) 리뷰를 거쳐 머지하는 프로세스를 도입해야 한다.
+
+## 20. RabbitMQ 큐 생성 주체 충돌 및 누락 이슈 (PRECONDITION_FAILED / NotAvailable)
+
+### 20.1. 문제 상황 (Problem)
+- **증상 1 (과거 - PRECONDITION_FAILED)**: AI 서버와 메인 서버가 각각 큐 생성을 시도하다가, 큐 속성(Durable 등) 불일치로 인해 보안 위반(`406 PRECONDITION_FAILED`) 에러가 발생하며 서버가 다운됨.
+- **증상 2 (현재 - QueuesNotAvailableException)**: 충돌을 피해 "AI 서버만 큐를 생성"하도록 규칙을 변경했으나, 이번에는 AI 서버가 켜지기 전 메인 서버가 먼저 배포(CD)되어 기동될 때 자신이 구독해야 할 `pvp.stt.response` 큐가 없는 것을 보고 예외를 던지며 메인 서버의 Health Check가 실패(다운)함.
+
+### 20.2. 원인 분석 (Root Cause)
+- **큐 생성의 멱등성 한계**: RabbitMQ에서 큐 생성(`declare`)은 이미 존재하더라도 옵션이 100% 동일하면 무시되지만, 양측 라이브러리(Java Spring vs Python aio_pika)의 디폴트 설정 차이 유무가 충돌을 일으켰음.
+- **메시징 아키텍처 원칙 위배**: AI 서버는 자기가 수신(Consume)할 5개의 큐만 생성하고 발행(Publish)할 큐는 생성하지 않음. 반면 메인 서버는 자기가 수신(Consume)해야 할 큐의 생성을 AI에게 떠넘김. 결과적으로 메인 서버 수신용 큐 2개는 아무도 생성하지 않는 사각지대에 놓임. Consumer는 대상 큐가 물리적으로 존재해야만 Bind/Listen을 시작할 수 있으므로 치명적 구조 결함 발생.
+
+### 20.3. 해결 방안 (Solution)
+**"자기가 구독(Consume)해서 읽어갈 큐는 자기가 뜰 때 스스로 만든다"** 원칙 도입.
+메인 서버(`4-team-IMYME-be`)의 RabbitMQ 설정 클래스에 다음 2개의 큐와 바인딩을 명시적으로 선언(Declare)하도록 코드 수정 지시.
+
+1. **`pvp.stt.response` 큐 생성 및 바인딩**
+2. **`pvp.feedback.response` 큐 생성 및 바인딩**
+
+### 20.4. 핵심 주의사항 (PRECONDITION_FAILED 재발 방지)
+과거의 충돌 악몽을 피하기 위해, 메인 서버가 응답 큐를 선언할 때 AI 서버(생산자)가 기대하는 스펙과 **단 하나의 속성도 어긋나면 안 됨.**
+- **Durable (영속성)**: 반드시 `true` 유지 (`QueueBuilder.durable(...)` 등 사용).
+- **Auto-delete, Exclusive**: 모두 기본값(`false`).
+- **Dead Letter Exchange (DLX)**: 응답 큐(`*.response`)에는 별도의 DLQ 라우팅 등 임의의 Arguments 추가 절대 금지.

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -386,3 +386,51 @@ user_text: str = Field(..., alias="userText", ...)
 ### 14.3. 변경 파일
 - `4-team-IMYME-ai/stt_server/config.py`: 파라미터 상수 정의.
 - `4-team-IMYME-ai/stt_server/services/inference_service.py`: `model.transcribe()` 호출 시 파라미터 주입 로직 추가.
+
+## 15. RunPod STT Timeout 및 RabbitMQ Queue 무한 대기 (Hang) 이슈
+
+### 15.1. 문제 상황 (Problem)
+- **증상**: 로컬 환경에서 PvP E2E 테스트를 진행할 때, 특정 상황(예: 유효하지 않은 오디오 URL 전달, RunPod 서버 지연 등)에서 STT Worker가 전혀 응답하지 않고 **영원히 멈춰있는(Hang) 현상** 발생.
+- **영향**: RabbitMQ 큐(`pvp.stt.request`)에 쌓인 메시지가 처리되지 않은 상태(Unacked)로 계속 머물러 있어, 전체 파이프라인의 데드락을 유발함.
+
+### 15.2. 원인 분석 (Root Cause)
+- Python의 `requests` 라이브러리는 HTTP 통신을 수행할 때 `timeout` 파라미터를 명시하지 않으면, 서버가 연결을 끊어주지 않는 한 **무한정 응답을 기다리게 됨**.
+- AI Server의 `runpod_client.py`에서 RunPod API로 작업 요청(`requests.post`) 및 상태 확인(`requests.get`)을 보낼 때 타임아웃 셋팅이 누락되어 있었음.
+
+### 15.3. 해결 방안 (Solution)
+모든 RunPod 외부 API 호출부에 **명시적인 Timeout(예: 60초)**을 추가하여 무한 루프를 방지.
+
+```python
+# 수정 전 (app/services/runpod_client.py)
+response = requests.post(run_url, headers=self.headers, json=payload)
+
+# 수정 후: 60초 타임아웃 추가
+response = requests.post(run_url, headers=self.headers, json=payload, timeout=60)
+```
+
+**효과**: RunPod 서버가 60초 내에 응답하지 않으면 코드에서 즉시 `requests.exceptions.Timeout` 예외를 발생시킴. 이를 통해 STT Worker의 기본 에러 핸들링 로직이 작동하여, 해당 요청을 건너뛰고 큐 메시지를 정상적으로 실패(`.status = "FAIL"`)로 후처리할 수 있게 됨.
+
+## 16. RabbitMQ DLQ 및 3회 재시도(Retry) 작동 불능 방지
+
+### 16.1. 문제 상황 (Problem)
+- **증상**: 일시적인 네트워크 오류나 RunPod 지연이 발생했을 때, 메시지가 RabbitMQ의 재시도 큐(Retry Queue)를 통해 3번 재시도되지 않고 **단 1회 실패 후 즉시 종료(FAIL 발행)**됨.
+- **원인**: Worker (`stt_worker.py`, `feedback_worker.py`) 코드 내부에 `try...except Exception as e:` 블록이 존재하여, 모든 예외를 스스로 먹고(Swallow) 직접 FAIL 응답을 쏜 뒤 함수를 정상 종료해버림. 이로 인해 인프라 레이어(`rabbitmq_service.py`)는 "작업이 성공적으로 끝났다"고 착각하고 메시지를 `Ack` 처리하여 재시도/DLQ 로직이 완전히 무력화됨.
+
+### 16.2. 해결 방안 (Solution)
+Worker에서 에러를 덮어두지 않고, 예외를 명시적으로 던져(Raise) **RabbitMQ 서비스 레이어로 에러 핸들링을 위임**하는 구조로 전면 개편.
+
+1. **Worker 레이어 개편 (Exception Propagation)**
+    - 워커의 비즈니스 로직을 감싸던 `try/except` 블록을 제거.
+    - 비즈니스/네트워크 예외 발생 시 Python의 기본 예외 전파(Propagation)를 통해 콜백 바깥으로 튕겨나가게 함.
+
+2. **RabbitMQ 인프라 레이어 보강 (`rabbitmq_service.py`)**
+    - `on_message` 핸들러의 `except Exception` 블록에서 에러를 캐치.
+    - **1~2차 실패**: 메시지를 `reject(requeue=False)`하여 5초 TTL이 걸린 재시도 큐로 라우팅.
+    - **3차 최종 실패 (`retry_count >= 2`)**: 
+        - 원본 메시지를 DLQ(`pvp.match.dlq`)로 이동 보관하여 추후 원인 분석 및 재처리 지원.
+        - 매칭이 무한 로딩에 빠지지 않도록 3번째 실패 시점에만 메인 서버로 `FAIL` 전문을 즉시 조립하여 Publish (`pvp.stt.response` 등).
+
+### 16.3. 효과 (Result)
+- 일시적 장애 발생 시 최대 3번(10초)까지 인프라 복원력을 확보하여 **억울한 FAIL 응답 감소**.
+- 에러 원본 페이로드가 파괴되지 않고 DLQ에 보존되어 **개발자 디버깅(Replay) 편의성 극대화**.
+

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -434,3 +434,130 @@ Worker에서 에러를 덮어두지 않고, 예외를 명시적으로 던져(Rai
 - 일시적 장애 발생 시 최대 3번(10초)까지 인프라 복원력을 확보하여 **억울한 FAIL 응답 감소**.
 - 에러 원본 페이로드가 파괴되지 않고 DLQ에 보존되어 **개발자 디버깅(Replay) 편의성 극대화**.
 
+
+## 17. LLM-as-a-Judge 위치 편향(Positional Bias) 및 Logprobs 추출 이슈
+
+### 17.1. 문제 상황 (Problem)
+- **증상 1 (위치 편향)**: 두 개의 답변(A, B)을 비교 평가하는 프롬프트에서, `gemini-2.5-flash` 모델이 **실제 품질과 무관하게 항상 두 번째(B) 혹은 첫 번째(A) 위치의 답변을 승자로 선택**하는 극단적인 위치 편향(Positional Bias) 현상이 확인됨.
+- **증상 2 (Logprobs 추출 실패)**: 편향을 수학적으로 교정하기 위해 PAIRS(Pairwise-preference Search) 기법을 도입하여 토큰 확률(logprobs)을 추출하려 했으나, 일반 API Key 환경에서는 `Logprobs is not enabled` 에러가 발생.
+- **증상 3 (Thinking 토큰 충돌)**: Vertex AI로 전환 후, 출력 토큰을 1개로 제한(`max_output_tokens=1`)하여 정답("1" 또는 "2")의 확률만 추출하려 했으나, 최신 Flash 모델들의 사전 내부 추론(Thinking) 기능이 발동되어 첫 토큰으로 `<thought>` 등을 출력하다가 잘려버림. 이로 인해 결과 텍스트가 빈 문자열(`EMPTY`)로 반환되고 필요한 logprobs를 얻지 못함.
+
+### 17.2. 원인 분석 (Root Cause)
+1. **API 권한**: Gemini 모델의 `logprobs` 기능은 철저히 **Google Cloud Vertex AI** 환경 전용으로 제한되어 있었음.
+2. **디코딩(Decoding) 간섭**: `max_output_tokens=1` 방식은 모델의 생성 "길이"만 자를 뿐, 모델이 어떤 단어를 선택할지(확률 공간)는 제어하지 못함. "Thinking" 모델들은 본능적으로 추론 토큰을 먼저 생성하려 하므로, 길이가 1로 제한된 상태에서는 정답 토큰("1", "2")에 도달하기 전에 응답이 강제 종료됨.
+
+### 17.3. 해결 방안 (Solution)
+**Constrained Decoding (제약 기반 디코딩) 및 Vertex AI 도입**
+
+1. **Vertex AI 클라이언트로 마이그레이션**:
+   - `google.genai` SDK 사용 및 `genai.Client(vertexai=True, project=..., location=...)` 로 초기화.
+   - 호환성을 위해 `gcloud auth application-default login`을 통해 로컬 인증 자격 증명(ADC) 설정.
+
+2. **Enum Schema를 통한 출력 제약 (Constrained Decoding)**:
+   - `max_output_tokens=1` 옵션을 제거하고, **공식 권장 방식인 `text/x.enum` 스키마 제약**으로 전면 교체.
+   ```python
+   # 수정 후: 스키마를 통해 출력 풀(Pool)을 아예 "1", "2"로 물리적 격리
+   config = types.GenerateContentConfig(
+       response_mime_type="text/x.enum",
+       response_schema={"type": "STRING", "enum": ["1", "2"]},
+       response_logprobs=True,
+       logprobs=5
+   )
+   ```
+   - **원리**: 모델의 예측 확률 공간 자체를 `["1", "2"]` 두 단어로 강제 제한함. 모델은 내부 추론(`<thought>`)을 하고 싶어도 해당 토큰이 허용되지 않으므로, 추론 과정을 건너뛰고 즉각적으로 "1" 또는 "2"에 대한 Logprob을 계산하여 반환하게 됨.
+
+### 17.4. 결과 및 효과 (Results)
+- **Logprob 정상 추출**: `gemini-3-flash-preview` 등 최신 Thinking 모델에서도 에러나 빈 응답 없이 "1"과 "2"의 토큰 확률 데이터를 안정적으로 얻어냄.
+- **편향의 원천 차단 (Surprise Finding)**: Enum Schema로 디코딩을 강하게 제약한 결과, 원래 순서와 무관하게 2번을 뽑던 편향 모델이 **Raw 텍스트 판정 단계에서부터 편향 없이 항상 더 나은 정답을(100%) 고르는 부수적인 효과(Debiasing Effect)**까지 달성함.
+- **최종 보정**: 추출된 Logprobs를 Softmax 정규화 및 양방향[A-B, B-A] 평균 교정(Bradley-Terry Model)에 사용하여, $\approx 99.7\%$의 매우 안정적이고 신뢰도 높은 확신 점수(Confidence Score)를 확보.
+
+
+## 18. RabbitMQ 큐 미생성 및 연결 실패 (Docker 네트워크 이슈)
+
+### 18.1. 문제 상황 (Problem)
+- **증상 1**: AI 서버 배포(CD) 후 RabbitMQ Management UI(`15671`)에 큐가 0개로 표시됨.
+- **증상 2**: AI 서버 로그에서 `CONNECTION_FORCED - broker forced connection closure with reason 'shutdown'` 에러 발생 후, `[Errno 111] Connect call failed ('127.0.0.1', 5672)` 에러가 5초 간격으로 무한 반복.
+    ```
+    ERROR:aiormq.connection:Unexpected connection close from remote
+      "amqp://admin:******@localhost:5672/",
+      Connection.Close(reply_code=320,
+      reply_text="CONNECTION_FORCED - broker forced connection closure
+                   with reason 'shutdown'")
+
+    ERROR:aiormq.connection:error when creating transport:
+      <AMQPConnectionError: (111, "Connect call failed ('127.0.0.1', 5672)")>
+    ```
+- **증상 3**: RabbitMQ Management UI 접속 시 `15672`는 흰 화면(접속 불가), `15671`에서만 접속 가능하나 큐가 비어있음.
+
+### 18.2. 원인 분석 (Root Cause)
+
+1. **Docker 네트워크 격리**: RabbitMQ 컨테이너의 포트가 `127.0.0.1:5672->5672/tcp`로 바인딩되어 있어 호스트 루프백에서만 접속 가능. AI 서버가 도커 컨테이너 내부에서 `localhost`를 호출하면 자기 자신(AI 컨테이너)을 가리키게 됨.
+2. **컨테이너 재시작 타이밍**: RabbitMQ 도커 컨테이너를 재시작하면서 기존 연결이 `CONNECTION_FORCED`로 강제 종료되었고, 재시작 완료 전에 AI 서버가 재접속을 시도하여 `Connection Refused` 발생.
+3. **레거시 프로세스 잔존**: AI 서버가 Docker 배포본이 아닌 우분투 OS에 직접 설치된 구버전 프로세스(PM2)로 실행되고 있었으며, `/home/ubuntu/mine/ai/shared/.env` 파일을 참조하고 있었음.
+
+### 18.3. 해결 방안 (Solution)
+
+1. **인프라 현황 파악**:
+    ```bash
+    sudo docker ps | grep rabbitmq  # → dev-rabbitmq healthy 확인
+    sudo netstat -tulpn | grep 5672  # → docker-proxy 확인
+    ```
+2. **실제 `.env` 파일 위치 특정 및 수정**: `/home/ubuntu/mine/ai/shared/.env`의 `RABBITMQ_URL`에서 `localhost`를 Docker 게이트웨이 IP(`172.17.0.1`) 또는 컨테이너 이름(`dev-rabbitmq`)으로 변경.
+3. **서비스 시작 순서 보장**: RabbitMQ 컨테이너가 `healthy` 상태가 된 후 AI 서버를 재시작.
+
+### 18.4. 교훈 (Lessons Learned)
+> Docker 환경에서 `localhost`는 "자기 자신의 컨테이너 내부"를 가리킨다. 호스트 OS에서 직접 실행되는 프로세스와 Docker 컨테이너 간 통신 시에는 반드시 Docker 네트워크 이름이나 호스트 게이트웨이 IP를 사용해야 한다.
+
+
+## 19. Pydantic 스키마 불일치로 인한 STT 메시지 전량 Reject
+
+### 19.1. 문제 상황 (Problem)
+- **증상**: RabbitMQ 연결이 정상화된 후, 메인 서버(Spring Boot)가 `pvp.stt.request` 큐로 보낸 메시지가 AI 서버의 Pydantic 검증 단계에서 전량 Reject 처리됨. 3회 재시도 후 DLQ로 이동.
+    ```
+    ERROR: 3 validation errors for STTRequest
+    match_id
+      Field required [input_value={'room_id': 27, 'user_id': 1, ...}]
+    user_id
+      Input should be a valid string [input_value=1, input_type=int]
+    file_url
+      Field required [input_value={'room_id': 27, 'user_id': 1, ...}]
+    ```
+
+### 19.2. 원인 분석 (Root Cause)
+AI 서버의 Pydantic 스키마(`pvp_schema.py`)와 메인 서버(Spring Boot)의 DTO 정의가 서로 다른 버전의 규격서를 참조하고 있었음. 양측 간 최종 스키마 동기화(Sync-up) 과정이 누락되어, 운영 환경에서 처음으로 통신할 때 불일치가 발견됨.
+
+| 필드 | AI 서버 (기존 코드) | 메인 서버 (실제 전송) | 불일치 |
+|------|---------------------|----------------------|--------|
+| 매치/방 ID | `match_id: str` | `room_id: int` | ❌ 키 이름 + 타입 |
+| 사용자 ID | `user_id: str` | `user_id: int` | ❌ 타입 |
+| 오디오 URL | `file_url: str` | `audio_url: str` | ❌ 키 이름 |
+| 모범 답안 | `modelAnswer: str` | `model_answer: str` | ❌ camelCase vs snake_case |
+
+### 19.3. 해결 방안 (Solution)
+메인 서버의 실제 전송 형식을 기준으로 AI 서버 코드를 전면 리팩토링 (9개 파일 수정).
+
+| # | 파일 | 변경 내용 |
+|---|------|----------|
+| 1 | `app/schemas/pvp_schema.py` | Pydantic 모델 전면 수정 (필드명, 타입, 구조) |
+| 2 | `app/workers/stt_worker.py` | `room_id`, `audio_url` 참조 변경 |
+| 3 | `app/workers/feedback_worker.py` | `room_id`, `feedbacks` 배열 구조 반영 |
+| 4 | `app/services/rabbitmq_service.py` | FAIL 응답 `room_id` 반영, `feedbacks:null` 추가 |
+| 5 | `app/services/pvp_feedback_service.py` | 반환 구조 배열화, 필드명 전면 교체 |
+| 6-9 | `tests/services/test_*.py` (4개) | 테스트 데이터 & assertion 수정 |
+
+**주요 스키마 변경 사항**:
+- `match_id` (str) → **`room_id` (int)**
+- `user_id` (str) → **`user_id` (int)**
+- `file_url` (str) → **`audio_url` (str)**
+- `modelAnswer` → **`model_answer`** (snake_case 통일)
+- Feedback Response: `feedback` (객체 `{user_A, user_B}`) → **`feedbacks` (배열 `[{...}, {...}]`)**
+- `summarize` → **`summary`**, `keyword` → **`keywords`**, `personalized` → **`personalized_feedback`**
+
+### 19.4. 검증 결과 (Verification)
+```
+======================= 40 passed, 6 warnings in 10.63s ========================
+```
+전체 40개 테스트(단위 + 통합) 100% 통과 확인.
+
+### 19.5. 교훈 (Lessons Learned)
+> 마이크로서비스 간 비동기 메시징에서 **"스키마 불일치"는 런타임에서야 발견되는 가장 흔하고 치명적인 버그**이다. `pvp_mq_schema.md`를 단일 진실 공급원(SSOT)으로 확정하고, 스키마 변경 시 반드시 양측(BE/AI) 리뷰를 거쳐 머지하는 프로세스를 도입해야 한다.

--- a/ai_server/app/core/config.py
+++ b/ai_server/app/core/config.py
@@ -30,6 +30,16 @@ class Settings(BaseSettings):
     # Internal Secret for Middleware Auth
     INTERNAL_SECRET_KEY: str = ""
 
+    # RabbitMQ Configuration (PvP Mode)
+    # RabbitMQ 설정 (PvP 모드)
+    RABBITMQ_URL: str = ""
+    STT_REQUEST_QUEUE: str = "pvp.stt.request"
+    STT_RESULT_QUEUE: str = "pvp.stt.response"
+    FEEDBACK_REQUEST_QUEUE: str = "pvp.feedback.request"
+    FEEDBACK_RESULT_QUEUE: str = "pvp.feedback.response"
+    PVP_EXCHANGE: str = "pvp.direct"
+    PVP_DLQ: str = "pvp.match.dlq"
+
     class Config:
         # Load settings from .env file if present
         # .env 파일이 존재하면 설정을 로드함

--- a/ai_server/app/core/prompts.py
+++ b/ai_server/app/core/prompts.py
@@ -207,26 +207,26 @@ Do NOT wrap the output in markdown code blocks. Output raw JSON only.
   "user_A": {{
     "user_id": "{user_a_id}",
     "score": 0,
-    "summarize": "이 사용자의 이해도와 핵심 포인트를 요약한 한 문장.",
-    "keyword": [
+    "summary": "이 사용자의 이해도와 핵심 포인트를 요약한 한 문장.",
+    "keywords": [
       "포함된 키워드: A, B",
       "누락된 키워드: C"
     ],
     "facts": "사실 관계가 정확하면 '사실 관계 정확함', 아니면 오류 지적.",
     "understanding": "이해 깊이 평가 (단순 암기 vs 내재화).",
-    "personalized": "PvP 전략 기반 비교 피드백. 상대방과의 비교를 반영한 코칭."
+    "personalized_feedback": "PvP 전략 기반 비교 피드백. 상대방과의 비교를 반영한 코칭."
   }},
   "user_B": {{
     "user_id": "{user_b_id}",
     "score": 0,
-    "summarize": "이 사용자의 이해도와 핵심 포인트를 요약한 한 문장.",
-    "keyword": [
+    "summary": "이 사용자의 이해도와 핵심 포인트를 요약한 한 문장.",
+    "keywords": [
       "포함된 키워드: A, B",
       "누락된 키워드: C"
     ],
     "facts": "사실 관계가 정확하면 '사실 관계 정확함', 아니면 오류 지적.",
     "understanding": "이해 깊이 평가 (단순 암기 vs 내재화).",
-    "personalized": "PvP 전략 기반 비교 피드백. 상대방과의 비교를 반영한 코칭."
+    "personalized_feedback": "PvP 전략 기반 비교 피드백. 상대방과의 비교를 반영한 코칭."
   }}
 }}
 """

--- a/ai_server/app/core/prompts.py
+++ b/ai_server/app/core/prompts.py
@@ -255,4 +255,3 @@ PVP_PERSONA_PROMPTS = {
     - **Personalized Writing Style**: "두 분의 대결은 치열했지만, 놀랍게도 두 분 모두 [Keyword Z]에 대해서는 침묵하셨네요. 이 빈틈을 먼저 채우는 쪽이 상위 1%가 될 수 있습니다!"
     """,
 }
-

--- a/ai_server/app/core/prompts.py
+++ b/ai_server/app/core/prompts.py
@@ -161,3 +161,98 @@ Output a single valid JSON object with a `results` array. Each element represent
 
 **CRITICAL**: You MUST evaluate EVERY item in `similars` and include it in the results array.
 """
+
+# PvP Mode System Prompt (2인 비교 피드백 생성용)
+# Solo 모드와 동일한 JSON 구조(summarize, keyword, facts, understanding, personalized)를 유저별 출력
+# personalized 필드에 들어갈 전략은 {pvp_strategy} 플레이스홀더로 외부(서비스)에서 주입
+PVP_SYSTEM_PROMPT = """
+[Role]
+You are an "Expert PvP Learning Coach & Analyst". You evaluate TWO users' answers against a single model criteria. You provide the same structured feedback as a solo coach (summarize, keyword, facts, understanding), PLUS a personalized comparative insight for each user.
+
+[Input Data]
+- Criteria: {criteria} (Contains the core keyword and the standard model answer)
+- User A (ID: {user_a_id}): {user_a_text}
+- User B (ID: {user_b_id}): {user_b_text}
+
+[Scoring Rubric (Strictly 0-100)]
+- 40 Points: Keyword Match (Did they use the exact required keyword?)
+- 40 Points: Accurate Fact (Is the explanation factually aligned with the model answer?)
+- 20 Points: Depth of Thought (Did they simply recall 'What', or analyze 'Why/How'?)
+
+[Task Process]
+1. **Keyword Extraction (Strict)**: Locate the sentence in `criteria` that explicitly lists the required keywords. Extract ONLY those keywords.
+2. **Analysis & Comparison**: Identify keywords present/missing in EACH user's answer.
+3. **Feedback Generation for EACH user**: Generate summarize, keyword, facts, understanding fields independently for each user (same quality as Solo mode).
+4. **Personalized Section**: Apply the PvP Strategy below to generate a COMPARATIVE personalized feedback for each user.
+
+[Your Current PvP Strategy for Personalized Section]
+{pvp_strategy}
+
+[Tone & Formatting Rules]
+1. **Tone**: Warm yet professional "해요체" (e.g., "~습니다.", "~하시네요!").
+2. **Length**: Each field should be 2~4 sentences. Provide enough detail for the user to actually learn something, but avoid unnecessary filler. The `personalized` field may be slightly longer (up to 5 sentences) since it carries the core comparative coaching insight.
+3. NO Markdown formatting (no **, no \\n, no bullet points) inside the JSON values.
+
+[Output Format]
+Output a SINGLE, perfectly valid JSON object matching the exact structure below.
+Do NOT wrap the output in markdown code blocks. Output raw JSON only.
+
+{{
+  "reasoning": "Brief internal analysis before generating feedback. (English or Korean, not shown to users)",
+  "user_A": {{
+    "user_id": "{user_a_id}",
+    "score": 0,
+    "summarize": "이 사용자의 이해도와 핵심 포인트를 요약한 한 문장.",
+    "keyword": [
+      "포함된 키워드: A, B",
+      "누락된 키워드: C"
+    ],
+    "facts": "사실 관계가 정확하면 '사실 관계 정확함', 아니면 오류 지적.",
+    "understanding": "이해 깊이 평가 (단순 암기 vs 내재화).",
+    "personalized": "PvP 전략 기반 비교 피드백. 상대방과의 비교를 반영한 코칭."
+  }},
+  "user_B": {{
+    "user_id": "{user_b_id}",
+    "score": 0,
+    "summarize": "이 사용자의 이해도와 핵심 포인트를 요약한 한 문장.",
+    "keyword": [
+      "포함된 키워드: A, B",
+      "누락된 키워드: C"
+    ],
+    "facts": "사실 관계가 정확하면 '사실 관계 정확함', 아니면 오류 지적.",
+    "understanding": "이해 깊이 평가 (단순 암기 vs 내재화).",
+    "personalized": "PvP 전략 기반 비교 피드백. 상대방과의 비교를 반영한 코칭."
+  }}
+}}
+"""
+
+# PvP Persona Strategies (Solo의 PERSONA_PROMPTS와 동일한 구조)
+# pvp_feedback_service.py에서 random.choice()로 4개 중 1개를 선택하여
+# PVP_SYSTEM_PROMPT의 {pvp_strategy} 자리에 주입합니다.
+PVP_PERSONA_PROMPTS = {
+    "skill_stealing": """
+    [PvP Strategy: Skill Stealing (상대의 무기 훔치기)]
+    - **Theory**: Bandura's Observational Learning (관찰 학습).
+    - **Goal**: For each user, identify what the OPPONENT did BETTER. Point out specific keywords, expressions, or analogies the opponent used that this user missed.
+    - **Personalized Writing Style**: "상대방은 '[키워드]'라는 표현을 사용해 점수를 땄습니다. 이 표현은 훔쳐올 만합니다!"
+    """,
+    "usp": """
+    [PvP Strategy: Unique Selling Point (나의 필살기)]
+    - **Theory**: Self-Efficacy (자기 효능감).
+    - **Goal**: For each user, identify what THIS user did BETTER than the opponent. Boost their confidence and self-efficacy.
+    - **Personalized Writing Style**: "하지만 '[개념]' 설명은 회원님이 훨씬 명확했습니다. 이 부분은 완벽한 승리입니다!"
+    """,
+    "depth": """
+    [PvP Strategy: Depth Analysis (사고의 깊이 - Bloom's Taxonomy)]
+    - **Theory**: Bloom's Taxonomy of Educational Objectives.
+    - **Goal**: Compare the cognitive level of each answer: [기억/이해] vs [적용/분석/평가/창조]. Identify who explained 'What' vs who explained 'Why'.
+    - **Personalized Writing Style**: "상대방은 정의만 나열했지만, 회원님은 왜 그런지 원리를 설명했습니다. 논리의 깊이에서 승리하셨습니다!"
+    """,
+    "common_blind_spot": """
+    [PvP Strategy: Common Blind Spot (공통의 사각지대)]
+    - **Theory**: Collaborative Growth (협력적 성장).
+    - **Goal**: Identify the "Keyword Z" or concept that BOTH users missed completely. Show that neither is perfect, fostering humility and a shared learning goal.
+    - **Personalized Writing Style**: "두 분의 대결은 치열했지만, 놀랍게도 두 분 모두 [Keyword Z]에 대해서는 침묵하셨네요. 이 빈틈을 먼저 채우는 쪽이 상위 1%가 될 수 있습니다!"
+    """,
+}
+

--- a/ai_server/app/core/prompts.py
+++ b/ai_server/app/core/prompts.py
@@ -175,9 +175,14 @@ You are an "Expert PvP Learning Coach & Analyst". You evaluate TWO users' answer
 - User B (ID: {user_b_id}): {user_b_text}
 
 [Scoring Rubric (Strictly 0-100)]
-- 40 Points: Keyword Match (Did they use the exact required keyword?)
-- 40 Points: Accurate Fact (Is the explanation factually aligned with the model answer?)
-- 20 Points: Depth of Thought (Did they simply recall 'What', or analyze 'Why/How'?)
+    - 40 Points: Keyword Match (Did they use the exact required keyword?)
+    - 40 Points: Accurate Fact (Is the explanation factually aligned with the model answer?)
+    - 20 Points: Depth of Thought (Did they simply recall 'What', or analyze 'Why/How'?)
+    
+    [CRITICAL RULE: STRICT TIE-BREAKING]
+    - User A and User B MUST NOT receive the exact same total score. 
+    - If the base scores are identical, you MUST evaluate the subtle nuances of expression, clarity, and depth to break the tie by adding or subtracting 1 point (e.g., 85 vs 84).
+    - A tie (e.g., 85 vs 85) is STRICTLY PROHIBITED.
 
 [Task Process]
 1. **Keyword Extraction (Strict)**: Locate the sentence in `criteria` that explicitly lists the required keywords. Extract ONLY those keywords.

--- a/ai_server/app/main.py
+++ b/ai_server/app/main.py
@@ -1,11 +1,13 @@
 from fastapi import FastAPI, Request, Security
 from fastapi.responses import JSONResponse
 from fastapi.security import APIKeyHeader
+from contextlib import asynccontextmanager
 from app.api.v1.router import api_router
 from app.core.config import settings
 from app.core.exception_handlers import add_exception_handlers
 from app.core.errors import ErrorCode
 from app.schemas.common import create_error_response
+import asyncio
 import logging
 
 # Configure logging
@@ -15,6 +17,43 @@ logger = logging.getLogger("imyme-ai-server")
 # Swagger Auth
 api_key_header = APIKeyHeader(name="x-internal-secret", auto_error=False)
 
+
+# Lifespan: RabbitMQ 워커를 앱 시작/종료 시 관리
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """
+    FastAPI Lifespan Context Manager.
+    앱 시작 시 RabbitMQ 연결 및 PvP 워커를 백그라운드로 구동하고,
+    앱 종료 시 연결을 안전하게 해제합니다.
+    """
+    try:
+        from app.services.rabbitmq_service import rabbitmq_service
+        from app.workers.stt_worker import start_stt_consumer
+        from app.workers.feedback_worker import start_feedback_consumer
+
+        # RabbitMQ 연결 초기화
+        await rabbitmq_service.connect()
+
+        # PvP 워커를 백그라운드 태스크로 구동
+        asyncio.create_task(start_stt_consumer())
+        asyncio.create_task(start_feedback_consumer())
+        logger.info("PvP workers started successfully.")
+
+    except Exception as e:
+        # RabbitMQ 연결 실패 시 앱은 정상 구동 (기존 REST API는 유지)
+        logger.warning(f"RabbitMQ connection failed: {e}. PvP workers disabled.")
+
+    yield
+
+    # Shutdown: RabbitMQ 연결 해제
+    try:
+        from app.services.rabbitmq_service import rabbitmq_service
+
+        await rabbitmq_service.close()
+    except Exception as e:
+        logger.warning(f"Error closing RabbitMQ: {e}")
+
+
 # Initialize FastAPI app
 # FastAPI 앱 초기화
 app = FastAPI(
@@ -22,6 +61,7 @@ app = FastAPI(
     openapi_url=f"{settings.API_V1_STR}/openapi.json",
     root_path=settings.ROOT_PATH,
     dependencies=[Security(api_key_header)],  # Add Global Security
+    lifespan=lifespan,  # RabbitMQ 워커 생명주기 관리
 )
 
 # Register global exception handlers for consistent error format

--- a/ai_server/app/schemas/pvp_schema.py
+++ b/ai_server/app/schemas/pvp_schema.py
@@ -2,7 +2,7 @@
 PvP Mode Message Payload Schemas.
 PvP 모드 RabbitMQ 메시지 페이로드 스키마 정의.
 
-pvp_spec.md 문서의 큐 규격에 맞춰 Request/Response 모델을 정의합니다.
+pvp_mq_schema.md 문서의 큐 규격에 맞춰 Request/Response 모델을 정의합니다.
 """
 
 from pydantic import BaseModel, Field
@@ -21,9 +21,9 @@ class STTRequest(BaseModel):
     S3 음성 파일 URL을 받아 텍스트로 변환을 요청합니다.
     """
 
-    match_id: str = Field(..., description="매치 ID (Pass-through)")
-    user_id: str = Field(..., description="사용자 ID (Pass-through)")
-    file_url: str = Field(..., description="S3 오디오 파일 URL")
+    room_id: int = Field(..., description="방 ID (Pass-through)")
+    user_id: int = Field(..., description="사용자 ID (Pass-through)")
+    audio_url: str = Field(..., description="S3 오디오 파일 URL")
     timestamp: int = Field(..., description="요청 시간 (Unix timestamp)")
 
 
@@ -33,8 +33,8 @@ class STTResponse(BaseModel):
     STT 변환 결과를 반환합니다.
     """
 
-    match_id: str = Field(..., description="매치 ID (Pass-through)")
-    user_id: str = Field(..., description="사용자 ID (Pass-through)")
+    room_id: int = Field(..., description="방 ID (Pass-through)")
+    user_id: int = Field(..., description="사용자 ID (Pass-through)")
     status: str = Field(..., description="처리 상태 (SUCCESS / FAIL)")
     stt_text: Optional[str] = Field(None, description="변환된 텍스트")
     error: Optional[str] = Field(None, description="실패 시 에러 메시지")
@@ -51,7 +51,7 @@ class PvpUserData(BaseModel):
     PvP 대결에 참여하는 개별 사용자 데이터.
     """
 
-    user_id: str = Field(..., description="사용자 ID")
+    user_id: int = Field(..., description="사용자 ID")
     user_text: str = Field(..., description="사용자의 STT 변환 텍스트")
 
 
@@ -61,7 +61,7 @@ class FeedbackCriteria(BaseModel):
     """
 
     keyword: str = Field(..., description="핵심 키워드")
-    modelAnswer: str = Field(..., description="모범 답안")
+    model_answer: str = Field(..., description="모범 답안")
 
 
 class FeedbackRequest(BaseModel):
@@ -70,7 +70,7 @@ class FeedbackRequest(BaseModel):
     2명의 사용자 STT 결과를 취합하여 비교 피드백을 요청합니다.
     """
 
-    match_id: str = Field(..., description="매치 ID")
+    room_id: int = Field(..., description="방 ID")
     criteria: FeedbackCriteria = Field(..., description="채점 기준")
     users: List[PvpUserData] = Field(
         ..., min_length=2, max_length=2, description="2명의 사용자 데이터"
@@ -81,26 +81,15 @@ class FeedbackRequest(BaseModel):
 class PvpUserFeedback(BaseModel):
     """
     개별 사용자에 대한 PvP 비교 피드백 상세.
-    Solo 모드와 동일한 JSON 구조 + score 필드.
     """
 
-    user_id: str = Field(..., description="사용자 ID")
+    user_id: int = Field(..., description="사용자 ID")
     score: int = Field(..., ge=0, le=100, description="종합 점수 (0-100)")
-    summarize: str = Field(..., description="이해도 요약 (한 문장)")
-    keyword: List[str] = Field(..., description="포함/누락 키워드 리스트")
+    summary: str = Field(..., description="이해도 요약 (한 문장)")
+    keywords: List[str] = Field(..., description="포함/누락 키워드 리스트")
     facts: str = Field(..., description="사실 관계 확인")
     understanding: str = Field(..., description="이해 깊이 평가")
-    personalized: str = Field(..., description="PvP 전략 기반 비교 피드백")
-
-
-class PvpFeedbackResult(BaseModel):
-    """
-    PvP 비교 피드백 전체 결과.
-    각 사용자별 피드백과 공통 피드백을 포함합니다.
-    """
-
-    user_A: PvpUserFeedback = Field(..., description="사용자 A 피드백")
-    user_B: PvpUserFeedback = Field(..., description="사용자 B 피드백")
+    personalized_feedback: str = Field(..., description="PvP 전략 기반 비교 피드백")
 
 
 class FeedbackResponse(BaseModel):
@@ -109,7 +98,7 @@ class FeedbackResponse(BaseModel):
     PvP 비교 분석 피드백 결과를 반환합니다.
     """
 
-    match_id: str = Field(..., description="매치 ID")
+    room_id: int = Field(..., description="방 ID")
     status: str = Field(..., description="처리 상태 (SUCCESS / FAIL)")
-    feedback: Optional[PvpFeedbackResult] = Field(None, description="비교 피드백 결과")
+    feedbacks: Optional[List[PvpUserFeedback]] = Field(None, description="비교 피드백 결과 배열")
     error: Optional[str] = Field(None, description="실패 시 에러 메시지")

--- a/ai_server/app/schemas/pvp_schema.py
+++ b/ai_server/app/schemas/pvp_schema.py
@@ -1,0 +1,117 @@
+"""
+PvP Mode Message Payload Schemas.
+PvP 모드 RabbitMQ 메시지 페이로드 스키마 정의.
+
+pvp_spec.md 문서의 큐 규격에 맞춰 Request/Response 모델을 정의합니다.
+"""
+
+from pydantic import BaseModel, Field
+from typing import List, Optional, Any, Dict
+
+
+# =============================================================
+# STT Worker Schemas (pvp.stt.request / pvp.stt.response)
+# STT 워커 메시지 스키마
+# =============================================================
+
+
+class STTRequest(BaseModel):
+    """
+    STT Request Payload: 메인 서버 → AI 서버
+    S3 음성 파일 URL을 받아 텍스트로 변환을 요청합니다.
+    """
+
+    match_id: str = Field(..., description="매치 ID (Pass-through)")
+    user_id: str = Field(..., description="사용자 ID (Pass-through)")
+    file_url: str = Field(..., description="S3 오디오 파일 URL")
+    timestamp: int = Field(..., description="요청 시간 (Unix timestamp)")
+
+
+class STTResponse(BaseModel):
+    """
+    STT Response Payload: AI 서버 → 메인 서버
+    STT 변환 결과를 반환합니다.
+    """
+
+    match_id: str = Field(..., description="매치 ID (Pass-through)")
+    user_id: str = Field(..., description="사용자 ID (Pass-through)")
+    status: str = Field(..., description="처리 상태 (SUCCESS / FAIL)")
+    stt_text: Optional[str] = Field(None, description="변환된 텍스트")
+    error: Optional[str] = Field(None, description="실패 시 에러 메시지")
+
+
+# =============================================================
+# Feedback Worker Schemas (pvp.feedback.request / pvp.feedback.response)
+# 피드백 워커 메시지 스키마
+# =============================================================
+
+
+class PvpUserData(BaseModel):
+    """
+    PvP 대결에 참여하는 개별 사용자 데이터.
+    """
+
+    user_id: str = Field(..., description="사용자 ID")
+    user_text: str = Field(..., description="사용자의 STT 변환 텍스트")
+
+
+class FeedbackCriteria(BaseModel):
+    """
+    피드백 생성을 위한 채점 기준 정보.
+    """
+
+    keyword: str = Field(..., description="핵심 키워드")
+    modelAnswer: str = Field(..., description="모범 답안")
+
+
+class FeedbackRequest(BaseModel):
+    """
+    Feedback Request Payload: 메인 서버 → AI 서버
+    2명의 사용자 STT 결과를 취합하여 비교 피드백을 요청합니다.
+    """
+
+    match_id: str = Field(..., description="매치 ID")
+    criteria: FeedbackCriteria = Field(..., description="채점 기준")
+    users: List[PvpUserData] = Field(
+        ..., min_length=2, max_length=2, description="2명의 사용자 데이터"
+    )
+    timestamp: int = Field(..., description="요청 시간 (Unix timestamp)")
+
+
+class PvpUserFeedback(BaseModel):
+    """
+    개별 사용자에 대한 PvP 비교 피드백 상세.
+    Solo 모드와 동일한 JSON 구조 + score 필드.
+    """
+
+    user_id: str = Field(..., description="사용자 ID")
+    score: int = Field(..., ge=0, le=100, description="종합 점수 (0-100)")
+    summarize: str = Field(..., description="이해도 요약 (한 문장)")
+    keyword: List[str] = Field(..., description="포함/누락 키워드 리스트")
+    facts: str = Field(..., description="사실 관계 확인")
+    understanding: str = Field(..., description="이해 깊이 평가")
+    personalized: str = Field(..., description="PvP 전략 기반 비교 피드백")
+
+
+class PvpFeedbackResult(BaseModel):
+    """
+    PvP 비교 피드백 전체 결과.
+    각 사용자별 피드백과 공통 피드백을 포함합니다.
+    """
+
+    user_A: PvpUserFeedback = Field(..., description="사용자 A 피드백")
+    user_B: PvpUserFeedback = Field(..., description="사용자 B 피드백")
+
+
+class FeedbackResponse(BaseModel):
+    """
+    Feedback Response Payload: AI 서버 → 메인 서버
+    PvP 비교 분석 피드백 결과를 반환합니다.
+    """
+
+    match_id: str = Field(..., description="매치 ID")
+    status: str = Field(..., description="처리 상태 (SUCCESS / FAIL)")
+    feedback: Optional[PvpFeedbackResult] = Field(
+        None, description="비교 피드백 결과"
+    )
+    error: Optional[str] = Field(None, description="실패 시 에러 메시지")

--- a/ai_server/app/schemas/pvp_schema.py
+++ b/ai_server/app/schemas/pvp_schema.py
@@ -6,7 +6,7 @@ pvp_spec.md 문서의 큐 규격에 맞춰 Request/Response 모델을 정의합�
 """
 
 from pydantic import BaseModel, Field
-from typing import List, Optional, Any, Dict
+from typing import List, Optional
 
 
 # =============================================================
@@ -111,7 +111,5 @@ class FeedbackResponse(BaseModel):
 
     match_id: str = Field(..., description="매치 ID")
     status: str = Field(..., description="처리 상태 (SUCCESS / FAIL)")
-    feedback: Optional[PvpFeedbackResult] = Field(
-        None, description="비교 피드백 결과"
-    )
+    feedback: Optional[PvpFeedbackResult] = Field(None, description="비교 피드백 결과")
     error: Optional[str] = Field(None, description="실패 시 에러 메시지")

--- a/ai_server/app/schemas/pvp_schema.py
+++ b/ai_server/app/schemas/pvp_schema.py
@@ -100,5 +100,7 @@ class FeedbackResponse(BaseModel):
 
     room_id: int = Field(..., description="방 ID")
     status: str = Field(..., description="처리 상태 (SUCCESS / FAIL)")
-    feedbacks: Optional[List[PvpUserFeedback]] = Field(None, description="비교 피드백 결과 배열")
+    feedbacks: Optional[List[PvpUserFeedback]] = Field(
+        None, description="비교 피드백 결과 배열"
+    )
     error: Optional[str] = Field(None, description="실패 시 에러 메시지")

--- a/ai_server/app/services/pvp_feedback_service.py
+++ b/ai_server/app/services/pvp_feedback_service.py
@@ -59,15 +59,15 @@ class PvpFeedbackService:
         """
         2명의 사용자 텍스트를 비교 분석하여 PvP 피드백을 생성합니다.
 
-        출력 JSON 구조는 Solo 모드와 동일합니다:
-        {summarize, keyword, facts, understanding, personalized} (유저별)
+        출력 JSON 구조는 배열 형태입니다:
+        [{summary, keywords, facts, understanding, personalized_feedback}, ...] (유저별)
 
         Args:
-            criteria: 채점 기준 (keyword, modelAnswer)
+            criteria: 채점 기준 (keyword, model_answer)
             users: 2명의 사용자 데이터 리스트 [{user_id, user_text}, ...]
 
         Returns:
-            PvP 비교 피드백 결과 딕셔너리 (user_A, user_B 키 포함)
+            PvP 비교 피드백 결과 리스트 (유저별 딕셔너리 배열)
         """
         user_a = users[0]
         user_b = users[1]
@@ -85,26 +85,26 @@ class PvpFeedbackService:
                 f"Returning mutual forfeit (draw) response."
             )
             draw_msg = "두 분 모두 답변 내용이 부족하여 승부를 가릴 수 없습니다."
-            return {
-                "user_A": {
+            return [
+                {
                     "user_id": user_a["user_id"],
                     "score": 0,
-                    "summarize": draw_msg,
-                    "keyword": ["포함된 키워드: 없음", "누락된 키워드: 전체"],
+                    "summary": draw_msg,
+                    "keywords": ["포함된 키워드: 없음", "누락된 키워드: 전체"],
                     "facts": draw_msg,
                     "understanding": draw_msg,
-                    "personalized": draw_msg,
+                    "personalized_feedback": draw_msg,
                 },
-                "user_B": {
+                {
                     "user_id": user_b["user_id"],
                     "score": 0,
-                    "summarize": draw_msg,
-                    "keyword": ["포함된 키워드: 없음", "누락된 키워드: 전체"],
+                    "summary": draw_msg,
+                    "keywords": ["포함된 키워드: 없음", "누락된 키워드: 전체"],
                     "facts": draw_msg,
                     "understanding": draw_msg,
-                    "personalized": draw_msg,
+                    "personalized_feedback": draw_msg,
                 },
-            }
+            ]
 
         # ===== Case B: 한쪽만 기권 (부전승) =====
         if a_short:
@@ -148,6 +148,19 @@ class PvpFeedbackService:
 
         # CoT reasoning 필드는 내부 추론용이므로 최종 응답에서 제거
         result.pop("reasoning", None)
+
+        # Gemini 응답이 {user_A, user_B} 객체 형태로 올 경우 배열로 변환
+        if isinstance(result, dict):
+            feedbacks = []
+            for key in ["user_A", "user_B"]:
+                if key in result:
+                    feedbacks.append(result[key])
+            if feedbacks:
+                return feedbacks
+
+        # 이미 배열 형태라면 그대로 반환
+        if isinstance(result, list):
+            return result
 
         return result
 

--- a/ai_server/app/services/pvp_feedback_service.py
+++ b/ai_server/app/services/pvp_feedback_service.py
@@ -1,0 +1,171 @@
+"""
+PvP Feedback Service Module.
+PvP 모드 비교 피드백 생성 서비스.
+
+RabbitMQ 워커로부터 독립된 비즈니스 로직 모듈로,
+Solo 모드의 feedback_service.py + prompt_manager.py와 동일한 패턴으로 설계되었습니다.
+
+주요 기능:
+- 랜덤 전략 선택: PVP_PERSONA_PROMPTS 4종 중 1개를 random.choice()로 선택
+- 사전 검증: Case A(양측 기권 → 무승부), Case B(편측 기권 → 부전승/LLM 호출)
+- 지수 백오프: Gemini API 호출 시 일시적 장애 대비 재시도
+- 프롬프트 연동: PVP_SYSTEM_PROMPT + 선택된 전략을 조합하여 피드백 생성
+"""
+
+import json
+import random
+import logging
+from typing import List, Dict, Any
+
+import google.generativeai as genai
+from tenacity import (
+    retry,
+    stop_after_attempt,
+    wait_exponential,
+    retry_if_exception_type,
+)
+
+from app.core.config import settings
+from app.core.prompts import PVP_SYSTEM_PROMPT, PVP_PERSONA_PROMPTS
+
+logger = logging.getLogger(__name__)
+
+# 솔로 모드(analysis_service.py)와 동일한 최소 텍스트 길이 기준
+MIN_TEXT_LENGTH = 5
+
+# 부전승 시 기권자의 텍스트를 대체할 문구
+FORFEIT_PLACEHOLDER = "(답변을 제출하지 않아 기권 처리되었습니다.)"
+
+
+class PvpFeedbackService:
+    """
+    PvP 비교 피드백을 생성하는 서비스 클래스.
+
+    Solo 모드의 PromptManager와 동일한 패턴:
+    - Solo: BASE_SYSTEM_PROMPT + random.choice(PERSONA_PROMPTS)
+    - PvP:  PVP_SYSTEM_PROMPT  + random.choice(PVP_PERSONA_PROMPTS)
+    """
+
+    def __init__(self):
+        self.model = None
+        self.strategies = list(PVP_PERSONA_PROMPTS.keys())
+        if settings.GEMINI_API_KEY:
+            genai.configure(api_key=settings.GEMINI_API_KEY)
+            self.model = genai.GenerativeModel("gemini-3-flash-preview")
+
+    async def generate_pvp_feedback(
+        self, criteria: dict, users: List[Dict[str, Any]]
+    ) -> dict:
+        """
+        2명의 사용자 텍스트를 비교 분석하여 PvP 피드백을 생성합니다.
+
+        출력 JSON 구조는 Solo 모드와 동일합니다:
+        {summarize, keyword, facts, understanding, personalized} (유저별)
+
+        Args:
+            criteria: 채점 기준 (keyword, modelAnswer)
+            users: 2명의 사용자 데이터 리스트 [{user_id, user_text}, ...]
+
+        Returns:
+            PvP 비교 피드백 결과 딕셔너리 (user_A, user_B 키 포함)
+        """
+        user_a = users[0]
+        user_b = users[1]
+
+        a_text = user_a.get("user_text", "").strip()
+        b_text = user_b.get("user_text", "").strip()
+
+        a_short = len(a_text) < MIN_TEXT_LENGTH
+        b_short = len(b_text) < MIN_TEXT_LENGTH
+
+        # ===== Case A: 양측 모두 기권 (무승부) =====
+        if a_short and b_short:
+            logger.info(
+                f"Both users submitted short text: A={len(a_text)}, B={len(b_text)}. "
+                f"Returning mutual forfeit (draw) response."
+            )
+            draw_msg = "두 분 모두 답변 내용이 부족하여 승부를 가릴 수 없습니다."
+            return {
+                "user_A": {
+                    "user_id": user_a["user_id"],
+                    "score": 0,
+                    "summarize": draw_msg,
+                    "keyword": ["포함된 키워드: 없음", "누락된 키워드: 전체"],
+                    "facts": draw_msg,
+                    "understanding": draw_msg,
+                    "personalized": draw_msg,
+                },
+                "user_B": {
+                    "user_id": user_b["user_id"],
+                    "score": 0,
+                    "summarize": draw_msg,
+                    "keyword": ["포함된 키워드: 없음", "누락된 키워드: 전체"],
+                    "facts": draw_msg,
+                    "understanding": draw_msg,
+                    "personalized": draw_msg,
+                },
+            }
+
+        # ===== Case B: 한쪽만 기권 (부전승) =====
+        if a_short:
+            logger.info(
+                f"User A submitted short text ({len(a_text)} chars). "
+                f"Replacing with forfeit placeholder for Win-by-Default."
+            )
+            user_a = {**user_a, "user_text": FORFEIT_PLACEHOLDER}
+
+        if b_short:
+            logger.info(
+                f"User B submitted short text ({len(b_text)} chars). "
+                f"Replacing with forfeit placeholder for Win-by-Default."
+            )
+            user_b = {**user_b, "user_text": FORFEIT_PLACEHOLDER}
+
+        # ===== 정상 흐름: 랜덤 전략 선택 + 프롬프트 조합 =====
+        # Solo의 PromptManager.get_system_prompt() 패턴과 동일
+        selected_strategy_key = random.choice(self.strategies)
+        selected_strategy = PVP_PERSONA_PROMPTS[selected_strategy_key]
+        logger.info(f"Selected PvP strategy: {selected_strategy_key}")
+
+        criteria_str = json.dumps(criteria, ensure_ascii=False, indent=2)
+
+        prompt = PVP_SYSTEM_PROMPT.format(
+            criteria=criteria_str,
+            user_a_id=user_a["user_id"],
+            user_a_text=user_a["user_text"],
+            user_b_id=user_b["user_id"],
+            user_b_text=user_b["user_text"],
+            pvp_strategy=selected_strategy,
+        )
+
+        raw_response = await self._call_gemini_with_retry(prompt)
+
+        # JSON 파싱: markdown 코드블록 제거 후 파싱
+        cleaned_text = (
+            raw_response.text.replace("```json", "").replace("```", "").strip()
+        )
+        result = json.loads(cleaned_text)
+
+        # CoT reasoning 필드는 내부 추론용이므로 최종 응답에서 제거
+        result.pop("reasoning", None)
+
+        return result
+
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=2, max=8),
+        retry=retry_if_exception_type(Exception),
+        reraise=True,
+    )
+    async def _call_gemini_with_retry(self, prompt: str):
+        """
+        Gemini API 호출을 지수 백오프로 재시도합니다.
+        429(Rate Limit)나 500 에러 시 2초, 4초, 8초 간격으로 최대 3회 재시도.
+        """
+        logger.info("Calling Gemini API for PvP feedback...")
+        response = await self.model.generate_content_async(prompt)
+        return response
+
+
+# 싱글톤 인스턴스
+pvp_feedback_service = PvpFeedbackService()

--- a/ai_server/app/services/rabbitmq_service.py
+++ b/ai_server/app/services/rabbitmq_service.py
@@ -224,9 +224,7 @@ class RabbitMQService:
                                 f"for match={fail_response['match_id']}"
                             )
                         except Exception as fail_err:
-                            logger.error(
-                                f"Failed to publish FAIL response: {fail_err}"
-                            )
+                            logger.error(f"Failed to publish FAIL response: {fail_err}")
 
                     logger.error(
                         f"Message moved to DLQ after {MAX_RETRY_COUNT} retries."

--- a/ai_server/app/services/rabbitmq_service.py
+++ b/ai_server/app/services/rabbitmq_service.py
@@ -162,7 +162,7 @@ class RabbitMQService:
                 body = json.loads(message.body.decode())
                 logger.info(
                     f"Consumed from '{queue_name}' (retry: {retry_count}): "
-                    f"match_id={body.get('match_id', 'N/A')}"
+                    f"room_id={body.get('room_id', 'N/A')}"
                 )
 
                 # Execute business logic callback (worker handler)
@@ -208,7 +208,7 @@ class RabbitMQService:
                         try:
                             original_body = json.loads(message.body.decode())
                             fail_response = {
-                                "match_id": original_body.get("match_id", "unknown"),
+                                "room_id": original_body.get("room_id", 0),
                                 "status": "FAIL",
                                 "error": (
                                     f"Message failed after {MAX_RETRY_COUNT} "
@@ -218,10 +218,13 @@ class RabbitMQService:
                             # Include user_id for STT responses
                             if "user_id" in original_body:
                                 fail_response["user_id"] = original_body["user_id"]
+                            # Include feedbacks:null for Feedback responses
+                            if "users" in original_body:
+                                fail_response["feedbacks"] = None
                             await self.publish(response_queue, fail_response)
                             logger.info(
                                 f"Published FAIL response to '{response_queue}' "
-                                f"for match={fail_response['match_id']}"
+                                f"for room={fail_response['room_id']}"
                             )
                         except Exception as fail_err:
                             logger.error(f"Failed to publish FAIL response: {fail_err}")

--- a/ai_server/app/services/rabbitmq_service.py
+++ b/ai_server/app/services/rabbitmq_service.py
@@ -1,10 +1,15 @@
 """
 RabbitMQ Service Module.
-RabbitMQ 비동기 통신 서비스 모듈.
 
-aio-pika의 RobustConnection을 사용하여 네트워크 단절 시 자동 재연결을 보장합니다.
-QoS(prefetch_count=1) 설정으로 워커당 1건씩 순차 처리하며,
-Manual Ack/Nack 패턴을 적용합니다.
+Provides asynchronous message queue communication using aio-pika's RobustConnection
+for automatic reconnection on network failures.
+
+Key features:
+- QoS (prefetch_count=1): Sequential processing, one message at a time per worker.
+- Manual Ack/Nack: Messages are acknowledged only after successful processing.
+- 3-Retry with DLQ: Failed messages are retried up to 3 times via a TTL-based
+  retry queue. On the 3rd failure, a FAIL response is published to the result
+  queue and the original message is moved to the DLQ for manual inspection.
 """
 
 import json
@@ -19,8 +24,15 @@ from app.core.config import settings
 
 logger = logging.getLogger(__name__)
 
-# DLQ 재시도 횟수 상한
+# Maximum number of retry attempts before moving to DLQ
 MAX_RETRY_COUNT = 3
+
+# Mapping: request queue name → response queue name
+# Used by the retry handler to publish FAIL responses on final failure.
+REQUEST_TO_RESPONSE_QUEUE = {
+    settings.STT_REQUEST_QUEUE: settings.STT_RESULT_QUEUE,
+    settings.FEEDBACK_REQUEST_QUEUE: settings.FEEDBACK_RESULT_QUEUE,
+}
 
 
 class RabbitMQService:
@@ -36,24 +48,24 @@ class RabbitMQService:
 
     async def connect(self) -> None:
         """
-        RabbitMQ 서버에 연결하고 채널, Exchange, DLQ를 초기화합니다.
-        RobustConnection을 사용하여 연결이 끊겨도 자동으로 재연결됩니다.
+        Connect to RabbitMQ and initialize channel, exchange, and DLQ.
+        Uses RobustConnection for automatic reconnection on network failure.
         """
         logger.info(f"Connecting to RabbitMQ: {settings.RABBITMQ_URL}")
 
-        # RobustConnection: 네트워크 단절 시 자동 재연결
+        # RobustConnection: automatic reconnection on network disruption
         self.connection = await aio_pika.connect_robust(settings.RABBITMQ_URL)
         self.channel = await self.connection.channel()
 
-        # QoS 설정: 워커당 동시에 1개의 메시지만 처리 (순차 처리 보장)
+        # QoS: process one message at a time per worker (sequential guarantee)
         await self.channel.set_qos(prefetch_count=1)
 
-        # Direct Exchange 선언 (durable: 서버 재시작 후에도 유지)
+        # Declare Direct Exchange (durable: survives server restart)
         self.exchange = await self.channel.declare_exchange(
             settings.PVP_EXCHANGE, ExchangeType.DIRECT, durable=True
         )
 
-        # DLQ (Dead Letter Queue) 선언: MAX_RETRY_COUNT 이후 최종 실패 메시지 보관용
+        # Declare DLQ: permanent storage for messages that exceeded MAX_RETRY_COUNT
         dlq = await self.channel.declare_queue(settings.PVP_DLQ, durable=True)
         await dlq.bind(self.exchange, routing_key=settings.PVP_DLQ)
 
@@ -61,33 +73,32 @@ class RabbitMQService:
 
     async def declare_and_bind_queue(self, queue_name: str) -> aio_pika.Queue:
         """
-        큐를 선언하고 Exchange에 바인딩합니다.
+        Declare a queue and bind it to the exchange.
 
-        [Retry 아키텍처]
-        실패 시 메시지 흐름:
-          원래 큐 → reject → 재시도큐(5초 TTL) → TTL 만료 → 원래 큐로 복귀
-          3회 모두 실패 → DLQ로 최종 이동
+        [Retry Architecture]
+        Message flow on failure:
+          Main Queue → reject → Retry Queue (5s TTL) → TTL expires → Main Queue
+          After 3 total failures → DLQ (permanent storage)
 
-        이 구조 덕분에 x-death 헤더의 count가 정상적으로 증가하여
-        nack(requeue=True)의 무한 루프 문제를 완벽히 방지합니다.
+        Using reject(requeue=False) instead of nack(requeue=True) ensures that
+        x-death header count increments correctly, preventing infinite retry loops.
         """
         retry_queue_name = f"{queue_name}.retry"
 
-        # 1) 재시도큐 선언: 5초 TTL 후 메시지가 원래 큐로 자동 복귀
+        # 1) Retry Queue: messages wait here for 5s TTL, then auto-route back
         await self.channel.declare_queue(
             retry_queue_name,
             durable=True,
             arguments={
                 "x-dead-letter-exchange": settings.PVP_EXCHANGE,
                 "x-dead-letter-routing-key": queue_name,
-                "x-message-ttl": 5000,  # 5초 대기 후 원래 큐로 복귀
+                "x-message-ttl": 5000,  # 5 second delay before retry
             },
         )
-        # 재시도큐를 Exchange에 바인딩
         retry_queue = await self.channel.get_queue(retry_queue_name)
         await retry_queue.bind(self.exchange, routing_key=retry_queue_name)
 
-        # 2) 원래 큐 선언: reject된 메시지를 재시도큐로 라우팅
+        # 2) Main Queue: rejected messages route to the retry queue above
         queue = await self.channel.declare_queue(
             queue_name,
             durable=True,
@@ -101,16 +112,16 @@ class RabbitMQService:
 
     async def publish(self, queue_name: str, message_body: dict) -> None:
         """
-        특정 큐에 JSON 메시지를 발행합니다.
-        delivery_mode=PERSISTENT로 설정하여 디스크에 저장됩니다.
+        Publish a JSON message to the specified queue.
+        delivery_mode=PERSISTENT ensures the message survives server restarts.
 
         Args:
-            queue_name: 대상 큐의 라우팅 키
-            message_body: 발행할 JSON 직렬화 가능한 딕셔너리
+            queue_name: Target queue's routing key
+            message_body: JSON-serializable dictionary to publish
         """
         message = Message(
             body=json.dumps(message_body, ensure_ascii=False).encode(),
-            delivery_mode=DeliveryMode.PERSISTENT,  # 메시지 영속성 보장
+            delivery_mode=DeliveryMode.PERSISTENT,
             content_type="application/json",
         )
         await self.exchange.publish(message, routing_key=queue_name)
@@ -122,24 +133,29 @@ class RabbitMQService:
         callback: Callable[[dict, AbstractIncomingMessage], Awaitable[None]],
     ) -> None:
         """
-        특정 큐를 구독하고 메시지가 올 때마다 callback을 실행합니다.
-        Manual Ack 모드로 동작하며, callback 완료 후 Ack를 전송합니다.
-        3회 재시도 후에도 실패하면 DLQ로 이동됩니다.
+        Subscribe to a queue and execute a callback for each incoming message.
+        Operates in Manual Ack mode; Ack is sent only after successful processing.
 
-        [Bug Fix] nack(requeue=True)는 x-death 헤더를 갱신하지 않으므로
-        retry_count가 영원히 0인 무한 루프를 발생시킵니다.
-        대신 reject(requeue=False)로 DLQ Exchange를 경유시켜
-        x-death count가 정상적으로 증가하도록 수정합니다.
+        [Retry Flow]
+        1. Worker raises Exception → message is reject(requeue=False)
+        2. Rejected message routes to retry queue (5s TTL delay)
+        3. After TTL expires, message returns to the main queue for retry
+        4. After MAX_RETRY_COUNT (3) failures:
+           - A FAIL response is published to the result queue
+             (so the main server can stop waiting and close the match)
+           - The original message is archived in DLQ for manual inspection
 
         Args:
-            queue_name: 구독할 큐 이름
-            callback: 메시지 처리 콜백 (parsed_body, raw_message)
+            queue_name: Queue name to subscribe to
+            callback: Message processing callback (parsed_body, raw_message)
         """
         queue = await self.declare_and_bind_queue(queue_name)
 
+        # Determine the response queue for publishing FAIL on final failure
+        response_queue = REQUEST_TO_RESPONSE_QUEUE.get(queue_name)
+
         async def on_message(message: AbstractIncomingMessage) -> None:
-            """개별 메시지 수신 핸들러 (Ack/Nack 관리)"""
-            # 재시도 횟수 확인 (x-death 헤더 기반)
+            """Per-message handler with Ack/Reject management."""
             retry_count = _get_retry_count(message)
 
             try:
@@ -149,47 +165,79 @@ class RabbitMQService:
                     f"match_id={body.get('match_id', 'N/A')}"
                 )
 
-                # 콜백 실행 (비즈니스 로직)
+                # Execute business logic callback (worker handler)
                 await callback(body, message)
 
-                # 모든 처리가 성공한 후에만 Ack 전송
+                # Ack only after all processing succeeds
                 await message.ack()
 
             except Exception as e:
                 logger.error(
                     f"Error processing message from '{queue_name}' "
-                    f"(retry {retry_count}/{MAX_RETRY_COUNT}): {e}"
+                    f"(retry {retry_count + 1}/{MAX_RETRY_COUNT}): {e}"
                 )
 
-                if retry_count < MAX_RETRY_COUNT:
-                    # 재시도 가능: reject → 재시도큐(TTL) 경유 → 원래 큐로 복귀
-                    # (x-death count가 자동 증가하여 무한 루프 방지)
+                if retry_count < MAX_RETRY_COUNT - 1:
+                    # ──────────────────────────────────────────────────
+                    # RETRYABLE: reject → retry queue (5s TTL) → back to main queue
+                    # x-death count auto-increments to prevent infinite loops
+                    # ──────────────────────────────────────────────────
                     await message.reject(requeue=False)
                     logger.warning(
                         f"Message rejected for retry via retry queue "
                         f"(attempt {retry_count + 1}/{MAX_RETRY_COUNT})"
                     )
                 else:
-                    # 재시도 초과: 원본 Ack 후 DLQ에 수동 발행
-                    # (reject하면 retry queue로 빠지므로, 수동으로 DLQ에 전송)
+                    # ──────────────────────────────────────────────────
+                    # FINAL FAILURE (3rd attempt): Ack + DLQ + FAIL response
+                    # ──────────────────────────────────────────────────
                     await message.ack()
+
+                    # 1) Archive the original message to DLQ for debugging/replay
                     try:
                         dlq_body = json.loads(message.body.decode())
                         dlq_body["_dlq_reason"] = str(e)
-                        dlq_body["_dlq_retry_count"] = retry_count
+                        dlq_body["_dlq_retry_count"] = retry_count + 1
                         await self.publish(settings.PVP_DLQ, dlq_body)
                     except Exception as dlq_err:
                         logger.error(f"Failed to publish to DLQ: {dlq_err}")
+
+                    # 2) Publish FAIL response to the result queue
+                    #    so the main server can terminate the match gracefully
+                    if response_queue:
+                        try:
+                            original_body = json.loads(message.body.decode())
+                            fail_response = {
+                                "match_id": original_body.get("match_id", "unknown"),
+                                "status": "FAIL",
+                                "error": (
+                                    f"Message failed after {MAX_RETRY_COUNT} "
+                                    f"retry attempts: {str(e)}"
+                                ),
+                            }
+                            # Include user_id for STT responses
+                            if "user_id" in original_body:
+                                fail_response["user_id"] = original_body["user_id"]
+                            await self.publish(response_queue, fail_response)
+                            logger.info(
+                                f"Published FAIL response to '{response_queue}' "
+                                f"for match={fail_response['match_id']}"
+                            )
+                        except Exception as fail_err:
+                            logger.error(
+                                f"Failed to publish FAIL response: {fail_err}"
+                            )
+
                     logger.error(
                         f"Message moved to DLQ after {MAX_RETRY_COUNT} retries."
                     )
 
-        # 큐 소비 시작 (no_ack=False → Manual Ack 모드)
+        # Start consuming (no_ack=False → Manual Ack mode)
         await queue.consume(on_message, no_ack=False)
         logger.info(f"Started consuming from '{queue_name}'")
 
     async def close(self) -> None:
-        """RabbitMQ 연결을 안전하게 종료합니다."""
+        """Safely close the RabbitMQ connection."""
         if self.connection and not self.connection.is_closed:
             await self.connection.close()
             logger.info("RabbitMQ connection closed.")
@@ -197,8 +245,8 @@ class RabbitMQService:
 
 def _get_retry_count(message: AbstractIncomingMessage) -> int:
     """
-    메시지 헤더의 x-death 정보에서 재시도 횟수를 추출합니다.
-    RabbitMQ가 Nack/Reject된 메시지에 자동으로 추가하는 메타데이터입니다.
+    Extract retry count from the x-death header.
+    RabbitMQ automatically adds this metadata when a message is rejected.
     """
     if message.headers and "x-death" in message.headers:
         x_death = message.headers["x-death"]
@@ -207,5 +255,5 @@ def _get_retry_count(message: AbstractIncomingMessage) -> int:
     return 0
 
 
-# 싱글톤 인스턴스 (기존 서비스 패턴과 일관성 유지)
+# Singleton instance (consistent with existing service patterns)
 rabbitmq_service = RabbitMQService()

--- a/ai_server/app/services/rabbitmq_service.py
+++ b/ai_server/app/services/rabbitmq_service.py
@@ -1,0 +1,211 @@
+"""
+RabbitMQ Service Module.
+RabbitMQ 비동기 통신 서비스 모듈.
+
+aio-pika의 RobustConnection을 사용하여 네트워크 단절 시 자동 재연결을 보장합니다.
+QoS(prefetch_count=1) 설정으로 워커당 1건씩 순차 처리하며,
+Manual Ack/Nack 패턴을 적용합니다.
+"""
+
+import json
+import logging
+from typing import Callable, Awaitable
+
+import aio_pika
+from aio_pika import ExchangeType, Message, DeliveryMode
+from aio_pika.abc import AbstractIncomingMessage
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+# DLQ 재시도 횟수 상한
+MAX_RETRY_COUNT = 3
+
+
+class RabbitMQService:
+    """
+    RabbitMQ 연결, 발행(Publish), 소비(Consume)를 관리하는 서비스 클래스.
+    RobustConnection을 통해 네트워크 단절 시 자동 재연결을 보장합니다.
+    """
+
+    def __init__(self):
+        self.connection: aio_pika.RobustConnection | None = None
+        self.channel: aio_pika.RobustChannel | None = None
+        self.exchange: aio_pika.Exchange | None = None
+
+    async def connect(self) -> None:
+        """
+        RabbitMQ 서버에 연결하고 채널, Exchange, DLQ를 초기화합니다.
+        RobustConnection을 사용하여 연결이 끊겨도 자동으로 재연결됩니다.
+        """
+        logger.info(f"Connecting to RabbitMQ: {settings.RABBITMQ_URL}")
+
+        # RobustConnection: 네트워크 단절 시 자동 재연결
+        self.connection = await aio_pika.connect_robust(settings.RABBITMQ_URL)
+        self.channel = await self.connection.channel()
+
+        # QoS 설정: 워커당 동시에 1개의 메시지만 처리 (순차 처리 보장)
+        await self.channel.set_qos(prefetch_count=1)
+
+        # Direct Exchange 선언 (durable: 서버 재시작 후에도 유지)
+        self.exchange = await self.channel.declare_exchange(
+            settings.PVP_EXCHANGE, ExchangeType.DIRECT, durable=True
+        )
+
+        # DLQ (Dead Letter Queue) 선언: MAX_RETRY_COUNT 이후 최종 실패 메시지 보관용
+        dlq = await self.channel.declare_queue(settings.PVP_DLQ, durable=True)
+        await dlq.bind(self.exchange, routing_key=settings.PVP_DLQ)
+
+        logger.info("RabbitMQ connection established successfully.")
+
+    async def declare_and_bind_queue(self, queue_name: str) -> aio_pika.Queue:
+        """
+        큐를 선언하고 Exchange에 바인딩합니다.
+
+        [Retry 아키텍처]
+        실패 시 메시지 흐름:
+          원래 큐 → reject → 재시도큐(5초 TTL) → TTL 만료 → 원래 큐로 복귀
+          3회 모두 실패 → DLQ로 최종 이동
+
+        이 구조 덕분에 x-death 헤더의 count가 정상적으로 증가하여
+        nack(requeue=True)의 무한 루프 문제를 완벽히 방지합니다.
+        """
+        retry_queue_name = f"{queue_name}.retry"
+
+        # 1) 재시도큐 선언: 5초 TTL 후 메시지가 원래 큐로 자동 복귀
+        await self.channel.declare_queue(
+            retry_queue_name,
+            durable=True,
+            arguments={
+                "x-dead-letter-exchange": settings.PVP_EXCHANGE,
+                "x-dead-letter-routing-key": queue_name,
+                "x-message-ttl": 5000,  # 5초 대기 후 원래 큐로 복귀
+            },
+        )
+        # 재시도큐를 Exchange에 바인딩
+        retry_queue = await self.channel.get_queue(retry_queue_name)
+        await retry_queue.bind(self.exchange, routing_key=retry_queue_name)
+
+        # 2) 원래 큐 선언: reject된 메시지를 재시도큐로 라우팅
+        queue = await self.channel.declare_queue(
+            queue_name,
+            durable=True,
+            arguments={
+                "x-dead-letter-exchange": settings.PVP_EXCHANGE,
+                "x-dead-letter-routing-key": retry_queue_name,
+            },
+        )
+        await queue.bind(self.exchange, routing_key=queue_name)
+        return queue
+
+    async def publish(self, queue_name: str, message_body: dict) -> None:
+        """
+        특정 큐에 JSON 메시지를 발행합니다.
+        delivery_mode=PERSISTENT로 설정하여 디스크에 저장됩니다.
+
+        Args:
+            queue_name: 대상 큐의 라우팅 키
+            message_body: 발행할 JSON 직렬화 가능한 딕셔너리
+        """
+        message = Message(
+            body=json.dumps(message_body, ensure_ascii=False).encode(),
+            delivery_mode=DeliveryMode.PERSISTENT,  # 메시지 영속성 보장
+            content_type="application/json",
+        )
+        await self.exchange.publish(message, routing_key=queue_name)
+        logger.info(f"Published message to '{queue_name}'")
+
+    async def consume(
+        self,
+        queue_name: str,
+        callback: Callable[[dict, AbstractIncomingMessage], Awaitable[None]],
+    ) -> None:
+        """
+        특정 큐를 구독하고 메시지가 올 때마다 callback을 실행합니다.
+        Manual Ack 모드로 동작하며, callback 완료 후 Ack를 전송합니다.
+        3회 재시도 후에도 실패하면 DLQ로 이동됩니다.
+
+        [Bug Fix] nack(requeue=True)는 x-death 헤더를 갱신하지 않으므로
+        retry_count가 영원히 0인 무한 루프를 발생시킵니다.
+        대신 reject(requeue=False)로 DLQ Exchange를 경유시켜
+        x-death count가 정상적으로 증가하도록 수정합니다.
+
+        Args:
+            queue_name: 구독할 큐 이름
+            callback: 메시지 처리 콜백 (parsed_body, raw_message)
+        """
+        queue = await self.declare_and_bind_queue(queue_name)
+
+        async def on_message(message: AbstractIncomingMessage) -> None:
+            """개별 메시지 수신 핸들러 (Ack/Nack 관리)"""
+            # 재시도 횟수 확인 (x-death 헤더 기반)
+            retry_count = _get_retry_count(message)
+
+            try:
+                body = json.loads(message.body.decode())
+                logger.info(
+                    f"Consumed from '{queue_name}' (retry: {retry_count}): "
+                    f"match_id={body.get('match_id', 'N/A')}"
+                )
+
+                # 콜백 실행 (비즈니스 로직)
+                await callback(body, message)
+
+                # 모든 처리가 성공한 후에만 Ack 전송
+                await message.ack()
+
+            except Exception as e:
+                logger.error(
+                    f"Error processing message from '{queue_name}' "
+                    f"(retry {retry_count}/{MAX_RETRY_COUNT}): {e}"
+                )
+
+                if retry_count < MAX_RETRY_COUNT:
+                    # 재시도 가능: reject → 재시도큐(TTL) 경유 → 원래 큐로 복귀
+                    # (x-death count가 자동 증가하여 무한 루프 방지)
+                    await message.reject(requeue=False)
+                    logger.warning(
+                        f"Message rejected for retry via retry queue "
+                        f"(attempt {retry_count + 1}/{MAX_RETRY_COUNT})"
+                    )
+                else:
+                    # 재시도 초과: 원본 Ack 후 DLQ에 수동 발행
+                    # (reject하면 retry queue로 빠지므로, 수동으로 DLQ에 전송)
+                    await message.ack()
+                    try:
+                        dlq_body = json.loads(message.body.decode())
+                        dlq_body["_dlq_reason"] = str(e)
+                        dlq_body["_dlq_retry_count"] = retry_count
+                        await self.publish(settings.PVP_DLQ, dlq_body)
+                    except Exception as dlq_err:
+                        logger.error(f"Failed to publish to DLQ: {dlq_err}")
+                    logger.error(
+                        f"Message moved to DLQ after {MAX_RETRY_COUNT} retries."
+                    )
+
+        # 큐 소비 시작 (no_ack=False → Manual Ack 모드)
+        await queue.consume(on_message, no_ack=False)
+        logger.info(f"Started consuming from '{queue_name}'")
+
+    async def close(self) -> None:
+        """RabbitMQ 연결을 안전하게 종료합니다."""
+        if self.connection and not self.connection.is_closed:
+            await self.connection.close()
+            logger.info("RabbitMQ connection closed.")
+
+
+def _get_retry_count(message: AbstractIncomingMessage) -> int:
+    """
+    메시지 헤더의 x-death 정보에서 재시도 횟수를 추출합니다.
+    RabbitMQ가 Nack/Reject된 메시지에 자동으로 추가하는 메타데이터입니다.
+    """
+    if message.headers and "x-death" in message.headers:
+        x_death = message.headers["x-death"]
+        if isinstance(x_death, list) and len(x_death) > 0:
+            return x_death[0].get("count", 0)
+    return 0
+
+
+# 싱글톤 인스턴스 (기존 서비스 패턴과 일관성 유지)
+rabbitmq_service = RabbitMQService()

--- a/ai_server/app/services/runpod_client.py
+++ b/ai_server/app/services/runpod_client.py
@@ -40,7 +40,7 @@ class RunPodClient:
             run_url = f"{self.base_url}/run"
 
             logger.info(f"Sending job to RunPod: {run_url}")
-            response = requests.post(run_url, headers=self.headers, json=payload)
+            response = requests.post(run_url, headers=self.headers, json=payload, timeout=60)
             response.raise_for_status()
 
             job_data = response.json()
@@ -74,7 +74,7 @@ class RunPodClient:
             run_url = f"{self.base_url}/run"
             logger.info(f"Sending warmup signal to RunPod({self.endpoint_id})...")
 
-            response = requests.post(run_url, headers=self.headers, json=payload)
+            response = requests.post(run_url, headers=self.headers, json=payload, timeout=60)
             response.raise_for_status()
 
             job_data = response.json()
@@ -90,7 +90,7 @@ class RunPodClient:
         start_time = time.time()
 
         while time.time() - start_time < settings.RUNPOD_TIMEOUT_SECONDS:
-            response = requests.get(status_url, headers=self.headers)
+            response = requests.get(status_url, headers=self.headers, timeout=60)
             response.raise_for_status()
 
             data = response.json()

--- a/ai_server/app/services/runpod_client.py
+++ b/ai_server/app/services/runpod_client.py
@@ -40,7 +40,9 @@ class RunPodClient:
             run_url = f"{self.base_url}/run"
 
             logger.info(f"Sending job to RunPod: {run_url}")
-            response = requests.post(run_url, headers=self.headers, json=payload, timeout=60)
+            response = requests.post(
+                run_url, headers=self.headers, json=payload, timeout=60
+            )
             response.raise_for_status()
 
             job_data = response.json()
@@ -74,7 +76,9 @@ class RunPodClient:
             run_url = f"{self.base_url}/run"
             logger.info(f"Sending warmup signal to RunPod({self.endpoint_id})...")
 
-            response = requests.post(run_url, headers=self.headers, json=payload, timeout=60)
+            response = requests.post(
+                run_url, headers=self.headers, json=payload, timeout=60
+            )
             response.raise_for_status()
 
             job_data = response.json()

--- a/ai_server/app/workers/feedback_worker.py
+++ b/ai_server/app/workers/feedback_worker.py
@@ -1,13 +1,22 @@
 """
 Feedback Worker Module.
-피드백 워커: RabbitMQ에서 2명의 STT 결과를 소비하여 비교 피드백을 반환합니다.
 
-pvp.feedback.request 큐에서 메시지를 소비하고,
-PvpFeedbackService를 통해 Gemini API로 비교 분석 피드백을 생성한 뒤,
-pvp.feedback.response 큐로 결과를 발행합니다.
+Consumes PvP feedback requests from the pvp.feedback.request queue,
+delegates the comparison analysis to PvpFeedbackService (Gemini API),
+and publishes the result to the pvp.feedback.response queue.
 
-워커 자체는 RabbitMQ 통신에만 집중하며,
-비즈니스 로직은 pvp_feedback_service.py에 완전히 위임합니다.
+The worker focuses solely on RabbitMQ communication;
+all business logic is fully delegated to pvp_feedback_service.py.
+
+[Error Handling Strategy]
+On failure, this worker does NOT publish a FAIL response itself.
+Instead, it re-raises the exception to let rabbitmq_service.py handle
+the 3-retry logic and DLQ routing. The FAIL response is only published
+by rabbitmq_service.py on the 3rd (final) failure attempt.
+
+Note: pvp_feedback_service.py has its own internal tenacity-based
+retry (3 attempts with exponential backoff) for Gemini API failures.
+This operates independently of the queue-level retry mechanism.
 """
 
 import logging
@@ -24,63 +33,56 @@ logger = logging.getLogger(__name__)
 
 async def handle_feedback_message(body: dict, message: AbstractIncomingMessage) -> None:
     """
-    피드백 요청 메시지를 처리하는 콜백 함수.
+    Callback function to process a feedback request message.
 
-    1. 메시지를 FeedbackRequest 스키마로 파싱
-    2. PvpFeedbackService에 비즈니스 로직 위임
-    3. 성공/실패에 따라 FeedbackResponse를 결과 큐에 발행
+    1. Parse the message body into a FeedbackRequest schema
+    2. Delegate to PvpFeedbackService (validation + backoff + Gemini call)
+    3. Publish a SUCCESS FeedbackResponse to the result queue
+
+    On failure, the exception is re-raised to trigger the RabbitMQ
+    retry mechanism (up to 3 attempts with 5s delay between each).
 
     Args:
-        body: 파싱된 JSON 메시지 본문
-        message: 원본 RabbitMQ 메시지 (Ack/Nack용)
+        body: Parsed JSON message body
+        message: Raw RabbitMQ message (for Ack/Nack)
     """
-    try:
-        # 1. Pydantic으로 페이로드 검증
-        request = FeedbackRequest(**body)
-        logger.info(
-            f"[Feedback Worker] Processing match={request.match_id}, "
-            f"users={[u.user_id for u in request.users]}"
-        )
+    # 1. Validate payload with Pydantic
+    request = FeedbackRequest(**body)
+    logger.info(
+        f"[Feedback Worker] Processing match={request.match_id}, "
+        f"users={[u.user_id for u in request.users]}"
+    )
 
-        # 2. 비즈니스 로직 위임 (Validation + Backoff + Gemini 호출)
-        users_data = [u.model_dump() for u in request.users]
-        feedback_result = await pvp_feedback_service.generate_pvp_feedback(
-            criteria=request.criteria.model_dump(),
-            users=users_data,
-        )
+    # 2. Delegate to business logic (Validation + Backoff + Gemini call)
+    users_data = [u.model_dump() for u in request.users]
+    feedback_result = await pvp_feedback_service.generate_pvp_feedback(
+        criteria=request.criteria.model_dump(),
+        users=users_data,
+    )
 
-        # 3. 성공 응답 생성 및 발행
-        response = FeedbackResponse(
-            match_id=request.match_id,
-            status="SUCCESS",
-            feedback=PvpFeedbackResult(**feedback_result),
-        )
+    # 3. Build and publish SUCCESS response
+    response = FeedbackResponse(
+        match_id=request.match_id,
+        status="SUCCESS",
+        feedback=PvpFeedbackResult(**feedback_result),
+    )
 
-        await rabbitmq_service.publish(
-            settings.FEEDBACK_RESULT_QUEUE, response.model_dump()
-        )
+    await rabbitmq_service.publish(
+        settings.FEEDBACK_RESULT_QUEUE, response.model_dump()
+    )
 
-        logger.info(f"[Feedback Worker] Completed match={request.match_id}")
+    logger.info(f"[Feedback Worker] Completed match={request.match_id}")
 
-    except Exception as e:
-        logger.error(f"[Feedback Worker] Business error: {e}")
-
-        # Business Error: 실패 응답을 결과 큐에 발행하고 Ack 처리
-        error_response = FeedbackResponse(
-            match_id=body.get("match_id", "unknown"),
-            status="FAIL",
-            error=str(e),
-        )
-
-        await rabbitmq_service.publish(
-            settings.FEEDBACK_RESULT_QUEUE, error_response.model_dump()
-        )
+    # NOTE: If any exception occurs above, it will propagate to
+    # rabbitmq_service.py's on_message handler, which will:
+    #   - Retry up to 3 times (via reject → retry queue → main queue)
+    #   - On 3rd failure: publish FAIL response + archive to DLQ
 
 
 async def start_feedback_consumer() -> None:
     """
-    피드백 요청 큐 소비를 시작합니다.
-    main.py의 lifespan에서 호출됩니다.
+    Start consuming from the feedback request queue.
+    Called from main.py's lifespan startup handler.
     """
     logger.info("[Feedback Worker] Starting consumer...")
     await rabbitmq_service.consume(

--- a/ai_server/app/workers/feedback_worker.py
+++ b/ai_server/app/workers/feedback_worker.py
@@ -1,0 +1,90 @@
+"""
+Feedback Worker Module.
+피드백 워커: RabbitMQ에서 2명의 STT 결과를 소비하여 비교 피드백을 반환합니다.
+
+pvp.feedback.request 큐에서 메시지를 소비하고,
+PvpFeedbackService를 통해 Gemini API로 비교 분석 피드백을 생성한 뒤,
+pvp.feedback.response 큐로 결과를 발행합니다.
+
+워커 자체는 RabbitMQ 통신에만 집중하며,
+비즈니스 로직은 pvp_feedback_service.py에 완전히 위임합니다.
+"""
+
+import logging
+
+from aio_pika.abc import AbstractIncomingMessage
+
+from app.core.config import settings
+from app.services.rabbitmq_service import rabbitmq_service
+from app.services.pvp_feedback_service import pvp_feedback_service
+from app.schemas.pvp_schema import FeedbackRequest, FeedbackResponse, PvpFeedbackResult
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_feedback_message(
+    body: dict, message: AbstractIncomingMessage
+) -> None:
+    """
+    피드백 요청 메시지를 처리하는 콜백 함수.
+
+    1. 메시지를 FeedbackRequest 스키마로 파싱
+    2. PvpFeedbackService에 비즈니스 로직 위임
+    3. 성공/실패에 따라 FeedbackResponse를 결과 큐에 발행
+
+    Args:
+        body: 파싱된 JSON 메시지 본문
+        message: 원본 RabbitMQ 메시지 (Ack/Nack용)
+    """
+    try:
+        # 1. Pydantic으로 페이로드 검증
+        request = FeedbackRequest(**body)
+        logger.info(
+            f"[Feedback Worker] Processing match={request.match_id}, "
+            f"users={[u.user_id for u in request.users]}"
+        )
+
+        # 2. 비즈니스 로직 위임 (Validation + Backoff + Gemini 호출)
+        users_data = [u.model_dump() for u in request.users]
+        feedback_result = await pvp_feedback_service.generate_pvp_feedback(
+            criteria=request.criteria.model_dump(),
+            users=users_data,
+        )
+
+        # 3. 성공 응답 생성 및 발행
+        response = FeedbackResponse(
+            match_id=request.match_id,
+            status="SUCCESS",
+            feedback=PvpFeedbackResult(**feedback_result),
+        )
+
+        await rabbitmq_service.publish(
+            settings.FEEDBACK_RESULT_QUEUE, response.model_dump()
+        )
+
+        logger.info(f"[Feedback Worker] Completed match={request.match_id}")
+
+    except Exception as e:
+        logger.error(f"[Feedback Worker] Business error: {e}")
+
+        # Business Error: 실패 응답을 결과 큐에 발행하고 Ack 처리
+        error_response = FeedbackResponse(
+            match_id=body.get("match_id", "unknown"),
+            status="FAIL",
+            error=str(e),
+        )
+
+        await rabbitmq_service.publish(
+            settings.FEEDBACK_RESULT_QUEUE, error_response.model_dump()
+        )
+
+
+async def start_feedback_consumer() -> None:
+    """
+    피드백 요청 큐 소비를 시작합니다.
+    main.py의 lifespan에서 호출됩니다.
+    """
+    logger.info("[Feedback Worker] Starting consumer...")
+    await rabbitmq_service.consume(
+        settings.FEEDBACK_REQUEST_QUEUE, handle_feedback_message
+    )

--- a/ai_server/app/workers/feedback_worker.py
+++ b/ai_server/app/workers/feedback_worker.py
@@ -22,9 +22,7 @@ from app.schemas.pvp_schema import FeedbackRequest, FeedbackResponse, PvpFeedbac
 logger = logging.getLogger(__name__)
 
 
-async def handle_feedback_message(
-    body: dict, message: AbstractIncomingMessage
-) -> None:
+async def handle_feedback_message(body: dict, message: AbstractIncomingMessage) -> None:
     """
     피드백 요청 메시지를 처리하는 콜백 함수.
 

--- a/ai_server/app/workers/feedback_worker.py
+++ b/ai_server/app/workers/feedback_worker.py
@@ -26,7 +26,7 @@ from aio_pika.abc import AbstractIncomingMessage
 from app.core.config import settings
 from app.services.rabbitmq_service import rabbitmq_service
 from app.services.pvp_feedback_service import pvp_feedback_service
-from app.schemas.pvp_schema import FeedbackRequest, FeedbackResponse, PvpFeedbackResult
+from app.schemas.pvp_schema import FeedbackRequest, FeedbackResponse, PvpUserFeedback
 
 logger = logging.getLogger(__name__)
 
@@ -49,7 +49,7 @@ async def handle_feedback_message(body: dict, message: AbstractIncomingMessage) 
     # 1. Validate payload with Pydantic
     request = FeedbackRequest(**body)
     logger.info(
-        f"[Feedback Worker] Processing match={request.match_id}, "
+        f"[Feedback Worker] Processing room={request.room_id}, "
         f"users={[u.user_id for u in request.users]}"
     )
 
@@ -61,17 +61,18 @@ async def handle_feedback_message(body: dict, message: AbstractIncomingMessage) 
     )
 
     # 3. Build and publish SUCCESS response
+    #    feedback_result is now a list of dicts (one per user)
     response = FeedbackResponse(
-        match_id=request.match_id,
+        room_id=request.room_id,
         status="SUCCESS",
-        feedback=PvpFeedbackResult(**feedback_result),
+        feedbacks=[PvpUserFeedback(**fb) for fb in feedback_result],
     )
 
     await rabbitmq_service.publish(
         settings.FEEDBACK_RESULT_QUEUE, response.model_dump()
     )
 
-    logger.info(f"[Feedback Worker] Completed match={request.match_id}")
+    logger.info(f"[Feedback Worker] Completed room={request.room_id}")
 
     # NOTE: If any exception occurs above, it will propagate to
     # rabbitmq_service.py's on_message handler, which will:

--- a/ai_server/app/workers/stt_worker.py
+++ b/ai_server/app/workers/stt_worker.py
@@ -36,8 +36,7 @@ async def handle_stt_message(body: dict, message: AbstractIncomingMessage) -> No
         # 1. Pydantic으로 페이로드 검증
         request = STTRequest(**body)
         logger.info(
-            f"[STT Worker] Processing match={request.match_id}, "
-            f"user={request.user_id}"
+            f"[STT Worker] Processing match={request.match_id}, user={request.user_id}"
         )
 
         # 2. RunPod STT 호출
@@ -56,13 +55,10 @@ async def handle_stt_message(body: dict, message: AbstractIncomingMessage) -> No
             stt_text=stt_result.get("text", ""),
         )
 
-        await rabbitmq_service.publish(
-            settings.STT_RESULT_QUEUE, response.model_dump()
-        )
+        await rabbitmq_service.publish(settings.STT_RESULT_QUEUE, response.model_dump())
 
         logger.info(
-            f"[STT Worker] Completed match={request.match_id}, "
-            f"user={request.user_id}"
+            f"[STT Worker] Completed match={request.match_id}, user={request.user_id}"
         )
 
     except Exception as e:
@@ -91,6 +87,4 @@ async def start_stt_consumer() -> None:
     main.py의 lifespan에서 호출됩니다.
     """
     logger.info("[STT Worker] Starting consumer...")
-    await rabbitmq_service.consume(
-        settings.STT_REQUEST_QUEUE, handle_stt_message
-    )
+    await rabbitmq_service.consume(settings.STT_REQUEST_QUEUE, handle_stt_message)

--- a/ai_server/app/workers/stt_worker.py
+++ b/ai_server/app/workers/stt_worker.py
@@ -43,7 +43,7 @@ async def handle_stt_message(body: dict, message: AbstractIncomingMessage) -> No
     # 1. Validate payload with Pydantic
     request = STTRequest(**body)
     logger.info(
-        f"[STT Worker] Processing match={request.match_id}, user={request.user_id}"
+        f"[STT Worker] Processing room={request.room_id}, user={request.user_id}"
     )
 
     # 2. Call RunPod STT
@@ -51,12 +51,12 @@ async def handle_stt_message(body: dict, message: AbstractIncomingMessage) -> No
     # so we delegate it to the thread pool to avoid blocking the event loop
     stt_result = await asyncio.to_thread(
         runpod_client.transcribe_sync,
-        audio_url=request.file_url,
+        audio_url=request.audio_url,
     )
 
     # 3. Build and publish SUCCESS response
     response = STTResponse(
-        match_id=request.match_id,
+        room_id=request.room_id,
         user_id=request.user_id,
         status="SUCCESS",
         stt_text=stt_result.get("text", ""),
@@ -65,7 +65,7 @@ async def handle_stt_message(body: dict, message: AbstractIncomingMessage) -> No
     await rabbitmq_service.publish(settings.STT_RESULT_QUEUE, response.model_dump())
 
     logger.info(
-        f"[STT Worker] Completed match={request.match_id}, user={request.user_id}"
+        f"[STT Worker] Completed room={request.room_id}, user={request.user_id}"
     )
 
     # NOTE: If any exception occurs above, it will propagate to

--- a/ai_server/app/workers/stt_worker.py
+++ b/ai_server/app/workers/stt_worker.py
@@ -1,0 +1,96 @@
+"""
+STT Worker Module.
+STT 워커: RabbitMQ에서 음성 URL을 소비하여 RunPod STT 결과를 반환합니다.
+
+pvp.stt.request 큐에서 메시지를 소비하고,
+RunPod STT 서버를 호출하여 텍스트를 추출한 뒤,
+pvp.stt.response 큐로 결과를 발행합니다.
+"""
+
+import logging
+import asyncio
+
+from aio_pika.abc import AbstractIncomingMessage
+
+from app.core.config import settings
+from app.services.rabbitmq_service import rabbitmq_service
+from app.services.runpod_client import runpod_client
+from app.schemas.pvp_schema import STTRequest, STTResponse
+
+logger = logging.getLogger(__name__)
+
+
+async def handle_stt_message(body: dict, message: AbstractIncomingMessage) -> None:
+    """
+    STT 요청 메시지를 처리하는 콜백 함수.
+
+    1. 메시지를 STTRequest 스키마로 파싱
+    2. RunPod STT 서버에 요청하여 텍스트 추출
+    3. 성공/실패에 따라 STTResponse를 결과 큐에 발행
+
+    Args:
+        body: 파싱된 JSON 메시지 본문
+        message: 원본 RabbitMQ 메시지 (Ack/Nack용)
+    """
+    try:
+        # 1. Pydantic으로 페이로드 검증
+        request = STTRequest(**body)
+        logger.info(
+            f"[STT Worker] Processing match={request.match_id}, "
+            f"user={request.user_id}"
+        )
+
+        # 2. RunPod STT 호출
+        # transcribe_sync는 blocking 함수(requests + time.sleep)이므로
+        # asyncio.to_thread로 스레드 풀에 위임하여 이벤트 루프 차단 방지
+        stt_result = await asyncio.to_thread(
+            runpod_client.transcribe_sync,
+            audio_url=request.file_url,
+        )
+
+        # 3. 성공 응답 생성 및 발행
+        response = STTResponse(
+            match_id=request.match_id,
+            user_id=request.user_id,
+            status="SUCCESS",
+            stt_text=stt_result.get("text", ""),
+        )
+
+        await rabbitmq_service.publish(
+            settings.STT_RESULT_QUEUE, response.model_dump()
+        )
+
+        logger.info(
+            f"[STT Worker] Completed match={request.match_id}, "
+            f"user={request.user_id}"
+        )
+
+    except Exception as e:
+        logger.error(f"[STT Worker] Business error: {e}")
+
+        # Business Error: 실패 응답을 결과 큐에 발행하고 Ack 처리
+        # (pvp_spec.md 에러 핸들링 규격 참조)
+        error_response = STTResponse(
+            match_id=body.get("match_id", "unknown"),
+            user_id=body.get("user_id", "unknown"),
+            status="FAIL",
+            error=str(e),
+        )
+
+        await rabbitmq_service.publish(
+            settings.STT_RESULT_QUEUE, error_response.model_dump()
+        )
+
+        # 비즈니스 에러이므로 예외를 다시 raise하지 않음 → Ack 처리됨
+        # (raise하면 rabbitmq_service의 Nack 로직이 트리거됨)
+
+
+async def start_stt_consumer() -> None:
+    """
+    STT 요청 큐 소비를 시작합니다.
+    main.py의 lifespan에서 호출됩니다.
+    """
+    logger.info("[STT Worker] Starting consumer...")
+    await rabbitmq_service.consume(
+        settings.STT_REQUEST_QUEUE, handle_stt_message
+    )

--- a/ai_server/app/workers/stt_worker.py
+++ b/ai_server/app/workers/stt_worker.py
@@ -1,10 +1,15 @@
 """
 STT Worker Module.
-STT 워커: RabbitMQ에서 음성 URL을 소비하여 RunPod STT 결과를 반환합니다.
 
-pvp.stt.request 큐에서 메시지를 소비하고,
-RunPod STT 서버를 호출하여 텍스트를 추출한 뒤,
-pvp.stt.response 큐로 결과를 발행합니다.
+Consumes audio file URLs from the pvp.stt.request queue,
+calls the RunPod STT server for speech-to-text conversion,
+and publishes the result to the pvp.stt.response queue.
+
+[Error Handling Strategy]
+On failure, this worker does NOT publish a FAIL response itself.
+Instead, it re-raises the exception to let rabbitmq_service.py handle
+the 3-retry logic and DLQ routing. The FAIL response is only published
+by rabbitmq_service.py on the 3rd (final) failure attempt.
 """
 
 import logging
@@ -22,69 +27,57 @@ logger = logging.getLogger(__name__)
 
 async def handle_stt_message(body: dict, message: AbstractIncomingMessage) -> None:
     """
-    STT 요청 메시지를 처리하는 콜백 함수.
+    Callback function to process an STT request message.
 
-    1. 메시지를 STTRequest 스키마로 파싱
-    2. RunPod STT 서버에 요청하여 텍스트 추출
-    3. 성공/실패에 따라 STTResponse를 결과 큐에 발행
+    1. Parse the message body into an STTRequest schema
+    2. Call the RunPod STT server to extract text
+    3. Publish a SUCCESS STTResponse to the result queue
+
+    On failure, the exception is re-raised to trigger the RabbitMQ
+    retry mechanism (up to 3 attempts with 5s delay between each).
 
     Args:
-        body: 파싱된 JSON 메시지 본문
-        message: 원본 RabbitMQ 메시지 (Ack/Nack용)
+        body: Parsed JSON message body
+        message: Raw RabbitMQ message (for Ack/Nack)
     """
-    try:
-        # 1. Pydantic으로 페이로드 검증
-        request = STTRequest(**body)
-        logger.info(
-            f"[STT Worker] Processing match={request.match_id}, user={request.user_id}"
-        )
+    # 1. Validate payload with Pydantic
+    request = STTRequest(**body)
+    logger.info(
+        f"[STT Worker] Processing match={request.match_id}, user={request.user_id}"
+    )
 
-        # 2. RunPod STT 호출
-        # transcribe_sync는 blocking 함수(requests + time.sleep)이므로
-        # asyncio.to_thread로 스레드 풀에 위임하여 이벤트 루프 차단 방지
-        stt_result = await asyncio.to_thread(
-            runpod_client.transcribe_sync,
-            audio_url=request.file_url,
-        )
+    # 2. Call RunPod STT
+    # transcribe_sync is a blocking function (requests + time.sleep),
+    # so we delegate it to the thread pool to avoid blocking the event loop
+    stt_result = await asyncio.to_thread(
+        runpod_client.transcribe_sync,
+        audio_url=request.file_url,
+    )
 
-        # 3. 성공 응답 생성 및 발행
-        response = STTResponse(
-            match_id=request.match_id,
-            user_id=request.user_id,
-            status="SUCCESS",
-            stt_text=stt_result.get("text", ""),
-        )
+    # 3. Build and publish SUCCESS response
+    response = STTResponse(
+        match_id=request.match_id,
+        user_id=request.user_id,
+        status="SUCCESS",
+        stt_text=stt_result.get("text", ""),
+    )
 
-        await rabbitmq_service.publish(settings.STT_RESULT_QUEUE, response.model_dump())
+    await rabbitmq_service.publish(settings.STT_RESULT_QUEUE, response.model_dump())
 
-        logger.info(
-            f"[STT Worker] Completed match={request.match_id}, user={request.user_id}"
-        )
+    logger.info(
+        f"[STT Worker] Completed match={request.match_id}, user={request.user_id}"
+    )
 
-    except Exception as e:
-        logger.error(f"[STT Worker] Business error: {e}")
-
-        # Business Error: 실패 응답을 결과 큐에 발행하고 Ack 처리
-        # (pvp_spec.md 에러 핸들링 규격 참조)
-        error_response = STTResponse(
-            match_id=body.get("match_id", "unknown"),
-            user_id=body.get("user_id", "unknown"),
-            status="FAIL",
-            error=str(e),
-        )
-
-        await rabbitmq_service.publish(
-            settings.STT_RESULT_QUEUE, error_response.model_dump()
-        )
-
-        # 비즈니스 에러이므로 예외를 다시 raise하지 않음 → Ack 처리됨
-        # (raise하면 rabbitmq_service의 Nack 로직이 트리거됨)
+    # NOTE: If any exception occurs above, it will propagate to
+    # rabbitmq_service.py's on_message handler, which will:
+    #   - Retry up to 3 times (via reject → retry queue → main queue)
+    #   - On 3rd failure: publish FAIL response + archive to DLQ
 
 
 async def start_stt_consumer() -> None:
     """
-    STT 요청 큐 소비를 시작합니다.
-    main.py의 lifespan에서 호출됩니다.
+    Start consuming from the STT request queue.
+    Called from main.py's lifespan startup handler.
     """
     logger.info("[STT Worker] Starting consumer...")
     await rabbitmq_service.consume(settings.STT_REQUEST_QUEUE, handle_stt_message)

--- a/ai_server/requirements.txt
+++ b/ai_server/requirements.txt
@@ -11,3 +11,6 @@ sentence-transformers>=2.7.0
 einops>=0.7.0
 torch>=2.2.0
 transformers>=4.38.0
+
+aio-pika>=9.4.0
+tenacity>=8.2.0


### PR DESCRIPTION
## 🎯 릴리즈 목적 (Release Notes)
이번 릴리즈는 **(1) 스프링 메인 서버와의 통신 규격(DTO) 100% 동기화**, **(2) LLM 판정의 공정성 및 무승부 방지 고도화**, 그리고 **(3) RabbitMQ 3-Retry/DLQ 아키텍처 복원 및 프로덕션 환경의 성능 모니터링 체계 구축**을 목표로 합니다.

---

## ✨ 핵심 변경 사항 (Key Features & Refactoring)

### 1. ⚔️ PvP 통신 규격 완벽 동기화 및 워커 안정화 (Schema Sync)
- **Request 페이로드 매핑**: 메인 서버 명세([pvp_mq_schema.md](cci:7://file:///Users/goorm/dir_ktbai/runpod_stt/md/pvp_mq_schema.md:0:0-0:0))에 맞춰 `match_id` -> `room_id`, `file_url` -> `audio_url`로 변경하고, `user_id`를 Number로 강제 파싱하도록 스키마 객체를 업데이트했습니다.
- **Response 페이로드 리스트화**: 메인 서버가 요구하는 `feedbacks: [{...}, {...}]` 리스트 배열 구조에 맞춰 JSON 출력부를 100% 호환되도록 리팩토링했습니다.
- **LLM 출력 스키마 누락(Missing) 대응**: `PVP_SYSTEM_PROMPT`의 JSON 출력 키값을 `summary`, `keywords`, `personalized_feedback`으로 최신화하여 Worker 단의 Pydantic Validation Error를 원천 차단했습니다.

### 2. 🤖 LLM 판정 정밀도 향상 및 편향 억제
- **PvP 무승부(Tie-Breaking) 전면 차단 로직 추가**: 두 유저의 답변 수준이 비슷하더라도 총점(Score)에서 완벽한 동점(e.g., 85 vs 85)이 나오지 않도록 프롬프트 규칙을 강화하여, 반드시 1점 이상의 승패 구분이 나뉘도록 강제했습니다.
- **순서 편향(Positional Bias) 해소**: Vertex AI (Gemini 1.5 Pro) 환경 도입과 Enum 스키마 제약을 통해 1번 유저와 2번 유저의 배치 순서에 영향을 받지 않고 오직 텍스트 논리성만으로 승자를 판정하도록 평가 신뢰도를 고도화했습니다.

### 3. 🛡️ RabbitMQ 오류 제어 복원 (3-Retry & DLQ)
- 워커(Worker) 내부에서 발생하는 Pydantic 검증 에러 및 LLM 호출 실패 등의 Exception이 조용히 먹히지 않고 RabbitMQ 서비스 레이어로 전파(`propagate`)되도록 수정했습니다.
- 이를 통해 실패한 메시지가 즉시 버려지지 않고 **최대 3회 재시도(Retry)** 후 최종적으로 **DLQ(Dead Letter Queue)**로 올바르게 이동하는 견고한 에러 핸들링 아키텍처를 복원했습니다.

### 4. 📈 인프라 통합 및 성능 모니터링 (Infra & CI/CD)
- **Prometheus Metrics Expose 구현 (`feat/metric`)**: AI 서버의 STT 변환 시간, LLM 추론 시간, RabbitMQ 처리량 등을 측정할 수 있는 `/metrics` 엔드포인트를 추가 구현했습니다. (`metrics.py` ruff 포맷팅 완료)
- **AI Release CI/CD 파이프라인 구축**: SSM(System Manager)을 활용한 안전한 배포 파이프라인과, 컨테이너 Healthcheck를 위한 curl 유틸리티를 Dockerfile에 통합했습니다.
- **인프라 교훈 문서화**: 개발망(도커 15672)과 운영망(Amazon MQ 15671)의 포트/엔드포인트 인지 오류 및 프로세스 기동 타이밍(Healthy) 불일치 해프닝을 [TROUBLESHOOTING.md](cci:7://file:///Users/goorm/dir_ktbai/runpod_stt/4-team-IMYME-ai/TROUBLESHOOTING.md:0:0-0:0)에 투명하게 상세 기록하여 팀 내 지식 자산으로 공유했습니다.

