### PR TITLE
Refactor STT server to use FastAPI and improve audio loader

### DIFF
--- a/stt_server/Dockerfile
+++ b/stt_server/Dockerfile
@@ -57,6 +57,7 @@ COPY stt_server/ /app/
 # 패키지 임포트를 위해 Python 경로 설정
 ENV PYTHONPATH=/app
 
-# Set the command to run the RunPod handler
-# RunPod 핸들러를 실행하기 위한 명령 설정
-CMD ["python", "-u", "/app/handler.py"]
+# Set the command to run the FastAPI app via uvicorn
+# FastAPI 서버를 구동하기 위해 Uvicorn을 실행
+# host 0.0.0.0으로 주어 외부(RunPod)에서 8000포트로 접근 가능하게 함
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/stt_server/handler.py
+++ b/stt_server/handler.py
@@ -6,13 +6,9 @@ import logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("runpod-handler")
 
-# Initialize Service
+# Initialize Service (ModelService singleton loads model in __new__)
 inference_service = InferenceService()
-
-# Initialize the model once during cold start
-logger.info("Initializing Inference Service...")
-inference_service.model_service.load_model()
-logger.info("Service initialized.")
+logger.info("Inference Service initialized.")
 
 
 # Handler function that RunPod calls for each request

--- a/stt_server/main.py
+++ b/stt_server/main.py
@@ -1,0 +1,80 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from contextlib import asynccontextmanager
+from services.inference_service import InferenceService
+import logging
+import uvicorn
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("stt-api")
+
+# Initialize Service early (ModelService singleton loads model in __new__)
+inference_service = InferenceService()
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """
+    Lifespan context manager for model initialization and cleanup.
+    모델 초기화 및 정리를 위한 Lifespan 컨텍스트 매니저.
+    """
+    logger.info(
+        "STT API Server started. Model already loaded via ModelService singleton."
+    )
+    yield
+    logger.info("STT API Server shutting down.")
+
+
+# Initialize FastAPI app with lifespan
+app = FastAPI(
+    title="RunPod STT Pod API",
+    description="API for Speech-to-Text inference running as a persistent Pod",
+    version="1.0.0",
+    lifespan=lifespan,
+)
+
+
+class TranscriptionRequest(BaseModel):
+    audio_url: str
+    language: str | None = None
+    warmup: bool | None = False
+
+
+@app.get("/health")
+async def health_check():
+    """Health check endpoint for the container."""
+    return {"status": "healthy"}
+
+
+@app.post("/transcribe")
+async def transcribe_audio(request: TranscriptionRequest):
+    """
+    Transcribe audio from a given URL.
+    This replaces the handler.py logic from RunPod Serverless.
+    """
+    from fastapi import HTTPException
+
+    if request.warmup:
+        logger.info("Warmup signal received. Returning immediately.")
+        return {"status": "success", "message": "Warmed up"}
+
+    if not request.audio_url:
+        raise HTTPException(status_code=400, detail="Missing 'audio_url' in request")
+
+    try:
+        logger.info(f"Processing transcription request for URL: {request.audio_url}")
+
+        # Call the transcription service (synchronously blocking)
+        result = inference_service.transcribe(request.audio_url, request.language)
+
+        return result
+
+    except Exception as e:
+        logger.error(f"Transcription failed: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+if __name__ == "__main__":
+    # When run directly, start standard HTTP server on port 8000
+    uvicorn.run("main:app", host="0.0.0.0", port=8000, log_level="info")

--- a/stt_server/requirements.txt
+++ b/stt_server/requirements.txt
@@ -3,3 +3,5 @@ faster-whisper==0.10.0
 pydantic==2.6.0
 pydantic-settings==2.1.0
 requests==2.31.0
+fastapi==0.109.2
+uvicorn==0.27.1

--- a/stt_server/utils/audio_loader.py
+++ b/stt_server/utils/audio_loader.py
@@ -20,11 +20,16 @@ class AudioLoader:
             response = requests.get(url, stream=True)
             response.raise_for_status()
 
+            # Determine file extension from URL (strip query params)
+            # URL에서 파일 확장자를 추출 (쿼리 파라미터 제거)
+            clean_url = url.split("?")[0]
+            ext = os.path.splitext(clean_url)[1] or ".mp3"
+
             # Create a temporary file to save the downloaded content
             # 다운로드한 내용을 저장할 임시 파일 생성
             # delete=False ensures the file exists after closing, so we can pass the path to Whisper
             # delete=False는 파일을 닫은 후에도 유지하여 Whisper에 경로를 전달할 수 있게 함
-            with tempfile.NamedTemporaryFile(delete=False, suffix=".mp3") as temp_file:
+            with tempfile.NamedTemporaryFile(delete=False, suffix=ext) as temp_file:
                 for chunk in response.iter_content(chunk_size=self.chunk_size):
                     if chunk:
                         temp_file.write(chunk)


### PR DESCRIPTION
## 💡 작업 배경
- 기존 RunPod 서버리스 핸들러 방식에서 벗어나, 독립적으로 동작할 수 있는 FastAPI 기반 상시 구동 서버로 `stt_server`의 구조를 개편합니다.
- 오디오 다운로드 시 `.mp3`로 하드코딩되어 있던 임시 파일 형식을 URL에서 다이나믹하게 추출하도록 개선했습니다.

## 🛠 주요 변경 사항
1. **FastAPI 기반 서버 전환**
   - `main.py`를 추가하여 FastAPI 애플리케이션 엔드포인트를 구현했습니다.
   - `Dockerfile`의 `CMD` 명령어를 `python handler.py`에서 `uvicorn main:app --host 0.0.0.0 --port 8000`으로 변경했습니다.
   - [requirements.txt](cci:7://file:///Users/goorm/dir_ktbai/runpod_stt/4-team-IMYME-ai/ai_server/requirements.txt:0:0-0:0)에 `fastapi` 및 `uvicorn`을 추가했습니다.
2. **`AudioLoader` 개선**
   - 오디오 파일을 다운로드할 때 쿼리 파라미터를 제외한 순수 URL에서 동적으로 파일 확장자를 추출하여 임시 파일을 생성(`NamedTemporaryFile(suffix=ext)`)하도록 로직을 수정했습니다.
3. **코드 품질 향상**
   - `ruff format` 및 `ruff check --fix`를 실행하여 `stt_server` 내부 코드의 린트와 포맷팅을 일괄 교정했습니다.

## 👀 리뷰 포인트
- FastAPI 애플리케이션(`main.py`) 전환에 따라 기존 워크플로우나 컨테이너 환경에서 포트 바인딩(8000번)이 올바르게 이루어지는지 확인 부탁드립니다.
- `AudioLoader`의 동적 확장자 추출 과정에서 발생할 수 있는 엣지 케이스(확장자가 없는 URL 등)의 기본값 처리(`.mp3`)가 적절한지 점검해 주세요.
