### PR TITLE
Feat/challenge mode pairs

### DIFF
--- a/ai_server/app/core/config.py
+++ b/ai_server/app/core/config.py
@@ -54,8 +54,22 @@ class Settings(BaseSettings):
     SOLO_EXCHANGE: str = "solo.direct"
     SOLO_DLQ: str = "ai.solo.dlq"
 
+    # RabbitMQ Configuration (Challenge Mode)
+    CHALLENGE_EVAL_QUEUE: str = "q.pairs.eval"
+    CHALLENGE_COMPLETED_QUEUE: str = "q.ranking.completed"
+    CHALLENGE_EXCHANGE: str = "challenge.direct"
+    CHALLENGE_DLQ: str = "ai.challenge.dlq"
+
+    # Redis Configuration
+    REDIS_URL: str = "redis://localhost:6379/0"
+
     # PostgreSQL (Knowledge Base - Shared with Spring Boot)
     DATABASE_URL: str = ""
+
+    # GCP Configuration (Vertex AI)
+    GCP_PROJECT: str = ""
+    GCP_LOCATION: str = ""
+    PAIRS_MODEL_ID: str = ""
 
     class Config:
         # Load settings from .env file if present

--- a/ai_server/app/core/config.py
+++ b/ai_server/app/core/config.py
@@ -55,13 +55,15 @@ class Settings(BaseSettings):
     SOLO_DLQ: str = "ai.solo.dlq"
 
     # RabbitMQ Configuration (Challenge Mode)
-    CHALLENGE_EVAL_QUEUE: str = "q.pairs.eval"
-    CHALLENGE_COMPLETED_QUEUE: str = "q.ranking.completed"
+    CHALLENGE_EVAL_QUEUE: str = "q.pairs.eval"  # Legacy alias
+    CHALLENGE_MERGE_QUEUE: str = "q.pairs.eval"  # AI 병합 작업 큐
+    CHALLENGE_FEEDBACK_QUEUE: str = "q.challenge.feedback"  # Fan-out 피드백 큐
+    CHALLENGE_COMPLETED_QUEUE: str = "challenge.final.done"  # BE 최종 완료 알림
     CHALLENGE_EXCHANGE: str = "challenge.direct"
     CHALLENGE_DLQ: str = "ai.challenge.dlq"
 
     # Redis Configuration
-    REDIS_URL: str = "redis://localhost:6379/0"
+    REDIS_URL: str = ""
 
     # PostgreSQL (Knowledge Base - Shared with Spring Boot)
     DATABASE_URL: str = ""

--- a/ai_server/app/core/prompts.py
+++ b/ai_server/app/core/prompts.py
@@ -277,3 +277,29 @@ PVP_PERSONA_PROMPTS = {
     </strategy_instruction>
     """,
 }
+
+# ─── Challenge Mode: PAIRS 지식 기반 비교 프롬프트 ───────────────────────────
+CHALLENGE_PAIRS_SYSTEM_PROMPT = """You are an expert technical evaluator for computer science knowledge.
+You will receive a grading rubric (Criteria) and two user answers to the same question.
+Your task is to determine which answer demonstrates better understanding based on the rubric.
+
+EVALUATION CRITERIA (in order of importance):
+1. Keyword Coverage (40%): Which answer includes more of the required keywords from the rubric?
+2. Factual Accuracy (40%): Which answer aligns better with the rubric's technical content?
+3. Depth of Understanding (20%): Which answer shows deeper comprehension beyond surface-level memorization?
+
+CRITICAL INSTRUCTION: You must respond with ONLY a single character: either "1" or "2".
+"1" means Answer 1 is better. "2" means Answer 2 is better.
+Do NOT write any explanation, reasoning, or additional text.
+Your entire response must be exactly one character."""
+
+CHALLENGE_PAIRS_USER_PROMPT = """[Grading Rubric / Criteria]
+{criteria}
+
+[Answer 1]
+{text_first}
+
+[Answer 2]
+{text_second}
+
+Which answer better satisfies the grading rubric? Respond with only "1" or "2"."""

--- a/ai_server/app/main.py
+++ b/ai_server/app/main.py
@@ -41,6 +41,7 @@ async def lifespan(app: FastAPI):
         from app.workers.feedback_worker import start_feedback_consumer
         from app.workers.solo_stt_worker import start_solo_stt_consumer
         from app.workers.solo_feedback_worker import start_solo_feedback_consumer
+        from app.workers.challenge_worker import start_challenge_consumer
 
         # RabbitMQ 연결 초기화
         await rabbitmq_service.connect()
@@ -54,6 +55,10 @@ async def lifespan(app: FastAPI):
         asyncio.create_task(start_solo_stt_consumer())
         asyncio.create_task(start_solo_feedback_consumer())
         logger.info("Solo workers started successfully.")
+
+        # Challenge 워커를 백그라운드 태스크로 구동
+        asyncio.create_task(start_challenge_consumer())
+        logger.info("Challenge workers started successfully.")
 
     except Exception as e:
         # RabbitMQ 연결 실패 시 앱은 정상 구동 (knowledge 등 REST API는 유지)

--- a/ai_server/app/main.py
+++ b/ai_server/app/main.py
@@ -42,6 +42,9 @@ async def lifespan(app: FastAPI):
         from app.workers.solo_stt_worker import start_solo_stt_consumer
         from app.workers.solo_feedback_worker import start_solo_feedback_consumer
         from app.workers.challenge_worker import start_challenge_consumer
+        from app.workers.challenge_feedback_worker import (
+            start_challenge_feedback_consumer,
+        )
 
         # RabbitMQ 연결 초기화
         await rabbitmq_service.connect()
@@ -58,7 +61,8 @@ async def lifespan(app: FastAPI):
 
         # Challenge 워커를 백그라운드 태스크로 구동
         asyncio.create_task(start_challenge_consumer())
-        logger.info("Challenge workers started successfully.")
+        asyncio.create_task(start_challenge_feedback_consumer())
+        logger.info("Challenge workers (merge + feedback) started successfully.")
 
     except Exception as e:
         # RabbitMQ 연결 실패 시 앱은 정상 구동 (knowledge 등 REST API는 유지)

--- a/ai_server/app/services/pairs_service.py
+++ b/ai_server/app/services/pairs_service.py
@@ -1,0 +1,236 @@
+import os
+import math
+import asyncio
+import logging
+from typing import List, Dict, Any, Tuple
+from google import genai
+from google.genai import types
+from tenacity import retry, wait_exponential, stop_after_attempt, retry_if_exception_type
+
+from app.core.config import settings
+
+# Configure logging
+logger = logging.getLogger("imyme-pairs-service")
+
+# GCP settings - typically loaded from environment/config
+# Init Vertex AI Client
+try:
+    client = genai.Client(
+        vertexai=True, 
+        project=settings.GCP_PROJECT, 
+        location=settings.GCP_LOCATION
+    )
+except Exception as e:
+    logger.warning(f"Failed to initialize Vertex AI client, fallback to standard GenAI might be needed: {e}")
+    # Fallback to standard client if vertex isn't properly configured in the environment
+    client = genai.Client()
+
+RESPONSE_SCHEMA = {"type": "STRING", "enum": ["1", "2"]}
+
+SYSTEM_PROMPT = """You are an expert technical evaluator. You will be given two answers to compare.
+CRITICAL INSTRUCTION: You must respond with ONLY a single character: either "1" or "2".
+Do NOT write any explanation, reasoning, or additional text.
+Your entire response must be exactly one character."""
+
+FALLBACK_LOGPROB = -100.0
+
+class PairsService:
+    def __init__(self, beam_size: int = 5, u_h: float = 0.6):
+        """
+        Initialize PAIRS Service with uncertainty guided pruning limits.
+        :param beam_size: Maximum number of trajectories to keep during beam search.
+        :param u_h: Uncertainty threshold. If $U(A, B) > U_h$, we branch.
+        """
+        self.beam_size = beam_size
+        self.u_h = u_h
+        # Semaphore as requested in "Proactive Warning" for Concurrency Throttling
+        self.api_semaphore = asyncio.Semaphore(10)
+
+    def _build_pairs_prompt(self, text_first: str, text_second: str) -> str:
+        return f"""Which of the following two answers is better?
+
+Answer 1:
+{text_first}
+
+Answer 2:
+{text_second}
+
+Respond with only "1" or "2". Nothing else."""
+
+    # Exponential backoff via tenacity as per "Proactive Warning"
+    @retry(
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        stop=stop_after_attempt(5),
+        reraise=True
+    )
+    async def _call_with_logprobs(self, prompt: str) -> dict:
+        """
+        Calls Gemini API asynchronously via asyncio.to_thread
+        and extracts log probabilities for '1' and '2'.
+        """
+        config = types.GenerateContentConfig(
+            system_instruction=SYSTEM_PROMPT,
+            temperature=0.0,
+            response_mime_type="text/x.enum",
+            response_schema=RESPONSE_SCHEMA,
+            response_logprobs=True,
+            logprobs=5,
+        )
+
+        async with self.api_semaphore:
+            # use to_thread because google.genai sdk might be synchronous for some calls
+            response = await asyncio.to_thread(
+                client.models.generate_content,
+                model=settings.PAIRS_MODEL_ID,
+                contents=prompt,
+                config=config,
+            )
+
+        logprobs_data = []
+        if response.candidates and response.candidates[0].logprobs_result:
+            logprobs_result = response.candidates[0].logprobs_result
+            if logprobs_result.top_candidates:
+                top = logprobs_result.top_candidates[0]
+                for candidate in top.candidates:
+                    logprobs_data.append({
+                        "token": candidate.token,
+                        "log_probability": candidate.log_probability
+                    })
+
+        return {
+            "top_candidates": logprobs_data,
+        }
+
+    def _extract_choice_probabilities(self, api_result: dict) -> Tuple[float, float]:
+        """Softmax normalization of logprobs. Returns (P(1), P(2))"""
+        logprob_1 = FALLBACK_LOGPROB
+        logprob_2 = FALLBACK_LOGPROB
+
+        for candidate in api_result.get("top_candidates", []):
+            token_stripped = candidate["token"].strip()
+            if token_stripped == "1":
+                logprob_1 = candidate["log_probability"]
+            elif token_stripped == "2":
+                logprob_2 = candidate["log_probability"]
+
+        exp_1 = math.exp(logprob_1)
+        exp_2 = math.exp(logprob_2)
+        total = exp_1 + exp_2
+
+        # Prevent division by zero if both are deeply negative
+        if total == 0:
+            return 0.5, 0.5
+
+        return exp_1 / total, exp_2 / total
+
+    def _compute_entropy(self, p_a: float, p_b: float) -> float:
+        """Compute the information entropy U(A, B)."""
+        eps = 1e-15
+        p_a = max(eps, min(1 - eps, p_a))
+        p_b = max(eps, min(1 - eps, p_b))
+        return -(p_a * math.log(p_a) + p_b * math.log(p_b))
+
+    async def compare_pair(self, item_a: dict, item_b: dict) -> Tuple[float, float, float]:
+        """
+        Phase 3: Calibration (위치 편향 제거)
+        item_a, item_b = {"id": str, "text": str}
+        Returns: P(A > B), P(B > A), Entropy U
+        """
+        text_a = item_a["text"]
+        text_b = item_b["text"]
+
+        # Prompt 1: A first, B second
+        prompt_ab = self._build_pairs_prompt(text_a, text_b)
+        res_ab = await self._call_with_logprobs(prompt_ab)
+        p_1_ab, p_2_ab = self._extract_choice_probabilities(res_ab)
+        p_A_in_prompt1 = p_1_ab
+
+        # Prompt 2: B first, A second
+        prompt_ba = self._build_pairs_prompt(text_b, text_a)
+        res_ba = await self._call_with_logprobs(prompt_ba)
+        p_1_ba, p_2_ba = self._extract_choice_probabilities(res_ba)
+        # B is first(1), A is second(2)
+        p_A_in_prompt2 = p_2_ba
+
+        # Calibrated Average
+        p_calibrated_A = (p_A_in_prompt1 + p_A_in_prompt2) / 2.0
+        p_calibrated_B = 1.0 - p_calibrated_A
+
+        # Entropy calculation based on calibrated probabilities
+        entropy = self._compute_entropy(p_calibrated_A, p_calibrated_B)
+
+        return p_calibrated_A, p_calibrated_B, entropy
+
+    # === Phase 4: PAIRS-beam Merge Sort Logics ===
+    
+    async def merge_beam(self, sub_arr1: List[dict], sub_arr2: List[dict]) -> List[dict]:
+        """
+        Merges two sorted subarrays using Uncertainty-Guided PAIRS-beam algorithm.
+        This represents Algorithm 1 from the paper.
+        Returns the single most likely merged list.
+        """
+        # A trajectory is a Tuple: (merged_list, pointer1, pointer2, likelihood)
+        initial_trajectory = ([], 0, 0, 1.0)
+        beam: List[Tuple[List[dict], int, int, float]] = [initial_trajectory]
+
+        len1 = len(sub_arr1)
+        len2 = len(sub_arr2)
+        
+        # We continue until all elements are merged
+        # In a real beam search, the loop condition is slightly tricky when tracking index pointers
+        # For simplicity, we loop until the best candidate is fully merged.
+        while True:
+            new_beam = []
+            
+            # If the top trajectory is done, we can just return it.
+            # Sort beam by likelihood (descending)
+            beam.sort(key=lambda x: x[3], reverse=True)
+            
+            # Check if best is done
+            best_list, p1, p2, best_L = beam[0]
+            if p1 == len1 and p2 == len2:
+                return best_list
+
+            # Expand each trajectory in the current beam
+            for merged_list, ptr1, ptr2, current_L in beam:
+                # If one array is fully consumed, automatically append the rest from the other
+                if ptr1 == len1:
+                    new_merged = list(merged_list) + sub_arr2[ptr2:]
+                    new_beam.append((new_merged, len1, len2, current_L))
+                    continue
+                if ptr2 == len2:
+                    new_merged = list(merged_list) + sub_arr1[ptr1:]
+                    new_beam.append((new_merged, len1, len2, current_L))
+                    continue
+
+                # Both have elements left, need to compare
+                item_a = sub_arr1[ptr1]
+                item_b = sub_arr2[ptr2]
+                
+                # Fetch comparison results
+                p_a, p_b, entropy = await self.compare_pair(item_a, item_b)
+
+                # Core Branching Logic (Algorithm 1: lines 10-17)
+                if entropy > self.u_h:
+                    # Branch 1: High uncertainty -> Fork
+                    new_l_a = list(merged_list) + [item_a]
+                    new_beam.append((new_l_a, ptr1 + 1, ptr2, current_L * p_a))
+                    
+                    new_l_b = list(merged_list) + [item_b]
+                    new_beam.append((new_l_b, ptr1, ptr2 + 1, current_L * p_b))
+                
+                elif p_a >= 0.5:
+                    # Branch 2: Definite win for A -> Prune B route
+                    new_l_a = list(merged_list) + [item_a]
+                    new_beam.append((new_l_a, ptr1 + 1, ptr2, current_L * p_a))
+                
+                else:
+                    # Branch 3: Definite win for B -> Prune A route
+                    new_l_b = list(merged_list) + [item_b]
+                    new_beam.append((new_l_b, ptr1, ptr2 + 1, current_L * p_b))
+
+            # Maintain beam size
+            new_beam.sort(key=lambda x: x[3], reverse=True)
+            beam = new_beam[:self.beam_size]
+
+pairs_service = PairsService()

--- a/ai_server/app/services/pairs_service.py
+++ b/ai_server/app/services/pairs_service.py
@@ -1,75 +1,80 @@
-import os
+"""
+PAIRS Algorithm Service (Phase 2: 설계.md 기반 리팩토링)
+
+지식베이스(Criteria)를 기반으로 두 답변을 비교하여
+Logprob + 위치 편향 보정 + Uncertainty-Guided Beam Search 를 수행합니다.
+"""
+
 import math
 import asyncio
 import logging
-from typing import List, Dict, Any, Tuple
+from typing import List, Tuple, Optional
 from google import genai
 from google.genai import types
-from tenacity import retry, wait_exponential, stop_after_attempt, retry_if_exception_type
+from tenacity import retry, wait_exponential, stop_after_attempt
 
 from app.core.config import settings
+from app.core.prompts import CHALLENGE_PAIRS_SYSTEM_PROMPT, CHALLENGE_PAIRS_USER_PROMPT
 
-# Configure logging
 logger = logging.getLogger("imyme-pairs-service")
 
-# GCP settings - typically loaded from environment/config
-# Init Vertex AI Client
+# ── Vertex AI Client 초기화 ──
 try:
     client = genai.Client(
-        vertexai=True, 
-        project=settings.GCP_PROJECT, 
-        location=settings.GCP_LOCATION
+        vertexai=True,
+        project=settings.GCP_PROJECT,
+        location=settings.GCP_LOCATION,
     )
 except Exception as e:
-    logger.warning(f"Failed to initialize Vertex AI client, fallback to standard GenAI might be needed: {e}")
-    # Fallback to standard client if vertex isn't properly configured in the environment
+    logger.warning(f"Failed to initialize Vertex AI client: {e}")
     client = genai.Client()
 
 RESPONSE_SCHEMA = {"type": "STRING", "enum": ["1", "2"]}
-
-SYSTEM_PROMPT = """You are an expert technical evaluator. You will be given two answers to compare.
-CRITICAL INSTRUCTION: You must respond with ONLY a single character: either "1" or "2".
-Do NOT write any explanation, reasoning, or additional text.
-Your entire response must be exactly one character."""
-
 FALLBACK_LOGPROB = -100.0
+
 
 class PairsService:
     def __init__(self, beam_size: int = 5, u_h: float = 0.6):
-        """
-        Initialize PAIRS Service with uncertainty guided pruning limits.
-        :param beam_size: Maximum number of trajectories to keep during beam search.
-        :param u_h: Uncertainty threshold. If $U(A, B) > U_h$, we branch.
-        """
         self.beam_size = beam_size
         self.u_h = u_h
-        # Semaphore as requested in "Proactive Warning" for Concurrency Throttling
         self.api_semaphore = asyncio.Semaphore(10)
 
-    def _build_pairs_prompt(self, text_first: str, text_second: str) -> str:
+    # User prompt
+    def _build_pairs_prompt(
+        self, text_first: str, text_second: str, criteria: Optional[str] = None
+    ) -> str:
+        """criteria가 있으면 지식 기반 비교 프롬프트, 없으면 단순 비교 프롬프트를 사용합니다."""
+        if criteria:
+            return CHALLENGE_PAIRS_USER_PROMPT.format(
+                criteria=criteria, text_first=text_first, text_second=text_second
+            )
         return f"""Which of the following two answers is better?
 
-Answer 1:
-{text_first}
+                    Answer 1:
+                    {text_first}
 
-Answer 2:
-{text_second}
+                    Answer 2:
+                    {text_second}
 
-Respond with only "1" or "2". Nothing else."""
+                    Respond with only "1" or "2". Nothing else."""
 
-    # Exponential backoff via tenacity as per "Proactive Warning"
+    # System instruction
+    def _get_system_prompt(self, criteria: Optional[str] = None) -> str:
+        if criteria:
+            return CHALLENGE_PAIRS_SYSTEM_PROMPT
+        return (
+            "You are an expert technical evaluator. "
+            "Respond with ONLY '1' or '2'. No explanation."
+        )
+
     @retry(
         wait=wait_exponential(multiplier=1, min=1, max=10),
         stop=stop_after_attempt(5),
-        reraise=True
+        reraise=True,
     )
-    async def _call_with_logprobs(self, prompt: str) -> dict:
-        """
-        Calls Gemini API asynchronously via asyncio.to_thread
-        and extracts log probabilities for '1' and '2'.
-        """
+    async def _call_with_logprobs(self, prompt: str, system_prompt: str) -> dict:
         config = types.GenerateContentConfig(
-            system_instruction=SYSTEM_PROMPT,
+            system_instruction=system_prompt,
             temperature=0.0,
             response_mime_type="text/x.enum",
             response_schema=RESPONSE_SCHEMA,
@@ -78,7 +83,6 @@ Respond with only "1" or "2". Nothing else."""
         )
 
         async with self.api_semaphore:
-            # use to_thread because google.genai sdk might be synchronous for some calls
             response = await asyncio.to_thread(
                 client.models.generate_content,
                 model=settings.PAIRS_MODEL_ID,
@@ -92,145 +96,115 @@ Respond with only "1" or "2". Nothing else."""
             if logprobs_result.top_candidates:
                 top = logprobs_result.top_candidates[0]
                 for candidate in top.candidates:
-                    logprobs_data.append({
-                        "token": candidate.token,
-                        "log_probability": candidate.log_probability
-                    })
+                    logprobs_data.append(
+                        {
+                            "token": candidate.token,
+                            "log_probability": candidate.log_probability,
+                        }
+                    )
 
-        return {
-            "top_candidates": logprobs_data,
-        }
+        return {"top_candidates": logprobs_data}
 
     def _extract_choice_probabilities(self, api_result: dict) -> Tuple[float, float]:
-        """Softmax normalization of logprobs. Returns (P(1), P(2))"""
         logprob_1 = FALLBACK_LOGPROB
         logprob_2 = FALLBACK_LOGPROB
 
-        for candidate in api_result.get("top_candidates", []):
-            token_stripped = candidate["token"].strip()
-            if token_stripped == "1":
-                logprob_1 = candidate["log_probability"]
-            elif token_stripped == "2":
-                logprob_2 = candidate["log_probability"]
+        for c in api_result.get("top_candidates", []):
+            t = c["token"].strip()
+            if t == "1":
+                logprob_1 = c["log_probability"]
+            elif t == "2":
+                logprob_2 = c["log_probability"]
 
         exp_1 = math.exp(logprob_1)
         exp_2 = math.exp(logprob_2)
         total = exp_1 + exp_2
-
-        # Prevent division by zero if both are deeply negative
         if total == 0:
             return 0.5, 0.5
-
         return exp_1 / total, exp_2 / total
 
     def _compute_entropy(self, p_a: float, p_b: float) -> float:
-        """Compute the information entropy U(A, B)."""
         eps = 1e-15
         p_a = max(eps, min(1 - eps, p_a))
         p_b = max(eps, min(1 - eps, p_b))
         return -(p_a * math.log(p_a) + p_b * math.log(p_b))
 
-    async def compare_pair(self, item_a: dict, item_b: dict) -> Tuple[float, float, float]:
-        """
-        Phase 3: Calibration (위치 편향 제거)
-        item_a, item_b = {"id": str, "text": str}
-        Returns: P(A > B), P(B > A), Entropy U
-        """
+    async def compare_pair(
+        self, item_a: dict, item_b: dict, criteria: Optional[str] = None
+    ) -> Tuple[float, float, float]:
+        """위치 편향 보정된 쌍방향 비교. criteria가 있으면 지식 기반 비교."""
         text_a = item_a["text"]
         text_b = item_b["text"]
+        sys_prompt = self._get_system_prompt(criteria)
 
         # Prompt 1: A first, B second
-        prompt_ab = self._build_pairs_prompt(text_a, text_b)
-        res_ab = await self._call_with_logprobs(prompt_ab)
-        p_1_ab, p_2_ab = self._extract_choice_probabilities(res_ab)
+        prompt_ab = self._build_pairs_prompt(text_a, text_b, criteria)
+        res_ab = await self._call_with_logprobs(prompt_ab, sys_prompt)
+        p_1_ab, _ = self._extract_choice_probabilities(res_ab)
         p_A_in_prompt1 = p_1_ab
 
-        # Prompt 2: B first, A second
-        prompt_ba = self._build_pairs_prompt(text_b, text_a)
-        res_ba = await self._call_with_logprobs(prompt_ba)
-        p_1_ba, p_2_ba = self._extract_choice_probabilities(res_ba)
-        # B is first(1), A is second(2)
+        # Prompt 2: B first, A second (위치 교환)
+        prompt_ba = self._build_pairs_prompt(text_b, text_a, criteria)
+        res_ba = await self._call_with_logprobs(prompt_ba, sys_prompt)
+        _, p_2_ba = self._extract_choice_probabilities(res_ba)
         p_A_in_prompt2 = p_2_ba
 
-        # Calibrated Average
+        # Calibrated average
         p_calibrated_A = (p_A_in_prompt1 + p_A_in_prompt2) / 2.0
         p_calibrated_B = 1.0 - p_calibrated_A
-
-        # Entropy calculation based on calibrated probabilities
         entropy = self._compute_entropy(p_calibrated_A, p_calibrated_B)
 
         return p_calibrated_A, p_calibrated_B, entropy
 
-    # === Phase 4: PAIRS-beam Merge Sort Logics ===
-    
-    async def merge_beam(self, sub_arr1: List[dict], sub_arr2: List[dict]) -> List[dict]:
-        """
-        Merges two sorted subarrays using Uncertainty-Guided PAIRS-beam algorithm.
-        This represents Algorithm 1 from the paper.
-        Returns the single most likely merged list.
-        """
-        # A trajectory is a Tuple: (merged_list, pointer1, pointer2, likelihood)
+    async def merge_beam(
+        self, sub_arr1: List[dict], sub_arr2: List[dict], criteria: Optional[str] = None
+    ) -> List[dict]:
+        """Uncertainty-Guided PAIRS-beam 병합 정렬. criteria가 있으면 지식 기반 비교."""
         initial_trajectory = ([], 0, 0, 1.0)
-        beam: List[Tuple[List[dict], int, int, float]] = [initial_trajectory]
+        beam: List[Tuple] = [initial_trajectory]
+        len1, len2 = len(sub_arr1), len(sub_arr2)
 
-        len1 = len(sub_arr1)
-        len2 = len(sub_arr2)
-        
-        # We continue until all elements are merged
-        # In a real beam search, the loop condition is slightly tricky when tracking index pointers
-        # For simplicity, we loop until the best candidate is fully merged.
         while True:
-            new_beam = []
-            
-            # If the top trajectory is done, we can just return it.
-            # Sort beam by likelihood (descending)
             beam.sort(key=lambda x: x[3], reverse=True)
-            
-            # Check if best is done
             best_list, p1, p2, best_L = beam[0]
             if p1 == len1 and p2 == len2:
                 return best_list
 
-            # Expand each trajectory in the current beam
+            new_beam = []
             for merged_list, ptr1, ptr2, current_L in beam:
-                # If one array is fully consumed, automatically append the rest from the other
                 if ptr1 == len1:
-                    new_merged = list(merged_list) + sub_arr2[ptr2:]
-                    new_beam.append((new_merged, len1, len2, current_L))
+                    new_beam.append(
+                        (list(merged_list) + sub_arr2[ptr2:], len1, len2, current_L)
+                    )
                     continue
                 if ptr2 == len2:
-                    new_merged = list(merged_list) + sub_arr1[ptr1:]
-                    new_beam.append((new_merged, len1, len2, current_L))
+                    new_beam.append(
+                        (list(merged_list) + sub_arr1[ptr1:], len1, len2, current_L)
+                    )
                     continue
 
-                # Both have elements left, need to compare
                 item_a = sub_arr1[ptr1]
                 item_b = sub_arr2[ptr2]
-                
-                # Fetch comparison results
-                p_a, p_b, entropy = await self.compare_pair(item_a, item_b)
+                p_a, p_b, entropy = await self.compare_pair(item_a, item_b, criteria)
 
-                # Core Branching Logic (Algorithm 1: lines 10-17)
                 if entropy > self.u_h:
-                    # Branch 1: High uncertainty -> Fork
-                    new_l_a = list(merged_list) + [item_a]
-                    new_beam.append((new_l_a, ptr1 + 1, ptr2, current_L * p_a))
-                    
-                    new_l_b = list(merged_list) + [item_b]
-                    new_beam.append((new_l_b, ptr1, ptr2 + 1, current_L * p_b))
-                
+                    new_beam.append(
+                        (list(merged_list) + [item_a], ptr1 + 1, ptr2, current_L * p_a)
+                    )
+                    new_beam.append(
+                        (list(merged_list) + [item_b], ptr1, ptr2 + 1, current_L * p_b)
+                    )
                 elif p_a >= 0.5:
-                    # Branch 2: Definite win for A -> Prune B route
-                    new_l_a = list(merged_list) + [item_a]
-                    new_beam.append((new_l_a, ptr1 + 1, ptr2, current_L * p_a))
-                
+                    new_beam.append(
+                        (list(merged_list) + [item_a], ptr1 + 1, ptr2, current_L * p_a)
+                    )
                 else:
-                    # Branch 3: Definite win for B -> Prune A route
-                    new_l_b = list(merged_list) + [item_b]
-                    new_beam.append((new_l_b, ptr1, ptr2 + 1, current_L * p_b))
+                    new_beam.append(
+                        (list(merged_list) + [item_b], ptr1, ptr2 + 1, current_L * p_b)
+                    )
 
-            # Maintain beam size
             new_beam.sort(key=lambda x: x[3], reverse=True)
-            beam = new_beam[:self.beam_size]
+            beam = new_beam[: self.beam_size]
+
 
 pairs_service = PairsService()

--- a/ai_server/app/services/rabbitmq_service.py
+++ b/ai_server/app/services/rabbitmq_service.py
@@ -102,9 +102,12 @@ class RabbitMQService:
         self.challenge_exchange = await self.channel.declare_exchange(
             settings.CHALLENGE_EXCHANGE, ExchangeType.DIRECT, durable=True
         )
-        challenge_dlq = await self.channel.declare_queue(settings.CHALLENGE_DLQ, durable=True)
-        await challenge_dlq.bind(self.challenge_exchange, routing_key=settings.CHALLENGE_DLQ)
-
+        challenge_dlq = await self.channel.declare_queue(
+            settings.CHALLENGE_DLQ, durable=True
+        )
+        await challenge_dlq.bind(
+            self.challenge_exchange, routing_key=settings.CHALLENGE_DLQ
+        )
 
         logger.info("RabbitMQ connection established successfully.")
 

--- a/ai_server/app/services/rabbitmq_service.py
+++ b/ai_server/app/services/rabbitmq_service.py
@@ -50,17 +50,22 @@ class RabbitMQService:
         self.channel: aio_pika.RobustChannel | None = None
         self.pvp_exchange: aio_pika.Exchange | None = None
         self.solo_exchange: aio_pika.Exchange | None = None
+        self.challenge_exchange: aio_pika.Exchange | None = None
 
     def _get_exchange(self, queue_name: str) -> aio_pika.Exchange:
         """Return the correct exchange based on queue name prefix or contained sub-string."""
         if "solo" in queue_name:
             return self.solo_exchange
+        if "pairs" in queue_name or "ranking" in queue_name:
+            return self.challenge_exchange
         return self.pvp_exchange
 
     def _get_dlq(self, queue_name: str) -> str:
         """Return the correct DLQ name based on queue name prefix."""
         if queue_name.startswith("solo."):
             return settings.SOLO_DLQ
+        if "pairs" in queue_name or "ranking" in queue_name:
+            return settings.CHALLENGE_DLQ
         return settings.PVP_DLQ
 
     async def connect(self) -> None:
@@ -92,6 +97,14 @@ class RabbitMQService:
         )
         solo_dlq = await self.channel.declare_queue(settings.SOLO_DLQ, durable=True)
         await solo_dlq.bind(self.solo_exchange, routing_key=settings.SOLO_DLQ)
+
+        # Challenge Mode Exchange & DLQ
+        self.challenge_exchange = await self.channel.declare_exchange(
+            settings.CHALLENGE_EXCHANGE, ExchangeType.DIRECT, durable=True
+        )
+        challenge_dlq = await self.channel.declare_queue(settings.CHALLENGE_DLQ, durable=True)
+        await challenge_dlq.bind(self.challenge_exchange, routing_key=settings.CHALLENGE_DLQ)
+
 
         logger.info("RabbitMQ connection established successfully.")
 

--- a/ai_server/app/services/redis_lua_script.py
+++ b/ai_server/app/services/redis_lua_script.py
@@ -1,0 +1,93 @@
+from typing import Optional, List
+import logging
+import redis.asyncio as aioredis
+
+logger = logging.getLogger("imyme-redis-lua")
+
+class RedisLuaScripts:
+    def __init__(self, redis_client):
+        """
+        Initializes Lua scripts for Challenge Mode (Phase 2).
+        Requires an active aioredis client.
+        """
+        self.redis = redis_client
+        self._push_and_check_script = None
+
+    async def init_scripts(self):
+        """
+        Loads the Lua script into Redis. Call this during app startup.
+        """
+        # Lua script: 
+        # 1. Pushes the merged_array into the target level list.
+        # 2. Checks if the list length >= 2.
+        # 3. If yes, pops 2 elements from the list and returns them so the worker can publish the next mission.
+        # 4. If no, returns nil.
+        # KEYS[1]: The Redis list key (e.g., pairs:job:999:level:1)
+        # ARGV[1]: The serialized JSON array string
+        push_check_lua = """
+        redis.call('RPUSH', KEYS[1], ARGV[1])
+        local len = redis.call('LLEN', KEYS[1])
+        if len >= 2 then
+            local p1 = redis.call('LPOP', KEYS[1])
+            local p2 = redis.call('LPOP', KEYS[1])
+            return {p1, p2}
+        else
+            return nil
+        end
+        """
+        self._push_and_check_script = self.redis.register_script(push_check_lua)
+        logger.info("Challenge Mode Lua scripts registered.")
+
+    async def push_and_check_pairs(self, list_key: str, serialized_array: str, ttl: int = 7200) -> Optional[List[str]]:
+        """
+        Atomically pushes a merged array into the level list and pops if a pair is formed.
+        Also guarantees TTL is applied to the key to prevent memory leaks (Infrastructure Checkpoint).
+        """
+        if not self._push_and_check_script:
+            raise RuntimeError("Lua scripts not initialized. Call init_scripts() first.")
+
+        # Ensure TTL is set on the key before or during the process.
+        # In a strict environment, TTL can be set inside the Lua script, 
+        # but for simplicity, we do it in python if it's the first element.
+        # We will use Lua to ensure atomicity.
+
+        lua_with_ttl = """
+        local key = KEYS[1]
+        local data = ARGV[1]
+        local ttl = tonumber(ARGV[2])
+        
+        -- Push data
+        redis.call('RPUSH', key, data)
+        
+        -- Set TTL if it doesn't have one
+        local current_ttl = redis.call('TTL', key)
+        if current_ttl == -1 or current_ttl == -2 then
+            redis.call('EXPIRE', key, ttl)
+        end
+        
+        -- Check and Pop
+        local len = redis.call('LLEN', key)
+        if len >= 2 then
+            local p1 = redis.call('LPOP', key)
+            local p2 = redis.call('LPOP', key)
+            return {p1, p2}
+        else
+            return {}
+        end
+        """
+        
+        # Override the simple script with the robust TTL embedded one
+        script = self.redis.register_script(lua_with_ttl)
+        
+        try:
+            result = await script(keys=[list_key], args=[serialized_array, str(ttl)])
+            if result and len(result) == 2:
+                # result is a list of two string-serialized arrays
+                return [r.decode("utf-8") if isinstance(r, bytes) else r for r in result]
+            return None
+        except Exception as e:
+            logger.error(f"Error executing push_and_check_pairs Lua script: {e}")
+            raise
+
+# A global instance placeholder, needs to be initialized with the actual redis client in main.py or dependencies
+# redis_lua_manager = RedisLuaScripts(redis_client)

--- a/ai_server/app/services/redis_lua_script.py
+++ b/ai_server/app/services/redis_lua_script.py
@@ -1,93 +1,110 @@
-from typing import Optional, List
+"""
+Challenge Mode Redis Lua Scripts (Phase 2: 설계.md 기반 리팩토링)
+
+스마트 Lua 스크립트:
+ - PAIR: 리스트에 2개 이상 쌓이면 2개를 팝하여 반환
+ - PROMOTE: 해당 레벨의 마지막 노드인데 짝이 없는 경우 (홀수 부전승)
+ - WAIT: 아직 짝꿍이 도착하지 않음
+"""
+
+from typing import List, Tuple
 import logging
 import redis.asyncio as aioredis
 
 logger = logging.getLogger("imyme-redis-lua")
 
+
 class RedisLuaScripts:
-    def __init__(self, redis_client):
-        """
-        Initializes Lua scripts for Challenge Mode (Phase 2).
-        Requires an active aioredis client.
-        """
+    def __init__(self, redis_client: aioredis.Redis):
         self.redis = redis_client
-        self._push_and_check_script = None
+        self._smart_push_script = None
 
     async def init_scripts(self):
-        """
-        Loads the Lua script into Redis. Call this during app startup.
-        """
-        # Lua script: 
-        # 1. Pushes the merged_array into the target level list.
-        # 2. Checks if the list length >= 2.
-        # 3. If yes, pops 2 elements from the list and returns them so the worker can publish the next mission.
-        # 4. If no, returns nil.
-        # KEYS[1]: The Redis list key (e.g., pairs:job:999:level:1)
-        # ARGV[1]: The serialized JSON array string
-        push_check_lua = """
-        redis.call('RPUSH', KEYS[1], ARGV[1])
-        local len = redis.call('LLEN', KEYS[1])
-        if len >= 2 then
-            local p1 = redis.call('LPOP', KEYS[1])
-            local p2 = redis.call('LPOP', KEYS[1])
-            return {p1, p2}
+        """서버 시작 시 Lua 스크립트를 Redis에 로드합니다."""
+        # KEYS[1] = level list key  (예: pairs:job:{id}:level:1)
+        # KEYS[2] = arrived counter (예: pairs:job:{id}:level:1:arrived)
+        # ARGV[1] = serialized merged array (JSON string)
+        # ARGV[2] = TTL (seconds)
+        # ARGV[3] = expected_count (이 레벨에 도달해야 할 총 노드 수)
+        #
+        # Returns:
+        #   {"PAIR", elem1, elem2}  -> 짝이 맞아서 병합 대상 2개 반환
+        #   {"PROMOTE", elem1}      -> 홀수 부전승: 이 레벨 마지막 노드
+        #   {"WAIT"}                -> 짝꿍을 더 기다려야 함
+        smart_lua = """
+        local list_key      = KEYS[1]
+        local arrived_key   = KEYS[2]
+        local data           = ARGV[1]
+        local ttl            = tonumber(ARGV[2])
+        local expected_count = tonumber(ARGV[3])
+
+        -- 1. Push data into the level list
+        redis.call('RPUSH', list_key, data)
+
+        -- 2. TTL 설정 (최초 1회)
+        local cur_ttl = redis.call('TTL', list_key)
+        if cur_ttl == -1 or cur_ttl == -2 then
+            redis.call('EXPIRE', list_key, ttl)
+        end
+
+        -- 3. 도달 카운터 증가 (이 레벨에 몇 개의 노드가 도착했는지)
+        local arrived = redis.call('INCR', arrived_key)
+        redis.call('EXPIRE', arrived_key, ttl)
+
+        -- 4. 리스트 길이 확인
+        local list_len = redis.call('LLEN', list_key)
+
+        -- 5. 분기 로직
+        if list_len >= 2 then
+            -- 짝이 맞음: 2개 꺼내서 반환
+            local p1 = redis.call('LPOP', list_key)
+            local p2 = redis.call('LPOP', list_key)
+            return {"PAIR", p1, p2}
+        elseif arrived == expected_count and list_len == 1 then
+            -- 이 레벨의 마지막 노드인데 짝이 없음 -> 부전승(Promote)
+            local lone = redis.call('LPOP', list_key)
+            return {"PROMOTE", lone}
         else
-            return nil
+            -- 아직 짝꿍 대기 중
+            return {"WAIT"}
         end
         """
-        self._push_and_check_script = self.redis.register_script(push_check_lua)
-        logger.info("Challenge Mode Lua scripts registered.")
+        self._smart_push_script = self.redis.register_script(smart_lua)
+        logger.info("Challenge Mode Smart Lua scripts registered.")
 
-    async def push_and_check_pairs(self, list_key: str, serialized_array: str, ttl: int = 7200) -> Optional[List[str]]:
+    async def push_and_route(
+        self,
+        list_key: str,
+        arrived_key: str,
+        serialized_array: str,
+        expected_count: int,
+        ttl: int = 7200,
+    ) -> Tuple[str, List[str]]:
         """
-        Atomically pushes a merged array into the level list and pops if a pair is formed.
-        Also guarantees TTL is applied to the key to prevent memory leaks (Infrastructure Checkpoint).
-        """
-        if not self._push_and_check_script:
-            raise RuntimeError("Lua scripts not initialized. Call init_scripts() first.")
+        원자적으로 병합 결과를 레벨 리스트에 넣고 다음 행동을 결정합니다.
 
-        # Ensure TTL is set on the key before or during the process.
-        # In a strict environment, TTL can be set inside the Lua script, 
-        # but for simplicity, we do it in python if it's the first element.
-        # We will use Lua to ensure atomicity.
-
-        lua_with_ttl = """
-        local key = KEYS[1]
-        local data = ARGV[1]
-        local ttl = tonumber(ARGV[2])
-        
-        -- Push data
-        redis.call('RPUSH', key, data)
-        
-        -- Set TTL if it doesn't have one
-        local current_ttl = redis.call('TTL', key)
-        if current_ttl == -1 or current_ttl == -2 then
-            redis.call('EXPIRE', key, ttl)
-        end
-        
-        -- Check and Pop
-        local len = redis.call('LLEN', key)
-        if len >= 2 then
-            local p1 = redis.call('LPOP', key)
-            local p2 = redis.call('LPOP', key)
-            return {p1, p2}
-        else
-            return {}
-        end
+        Returns:
+            ("PAIR", [arr1_json, arr2_json])   - 짝이 맞아 병합할 2개 반환
+            ("PROMOTE", [lone_arr_json])       - 홀수 부전승, 승급 대상 1개 반환
+            ("WAIT", [])                       - 짝꿍 대기 중
         """
-        
-        # Override the simple script with the robust TTL embedded one
-        script = self.redis.register_script(lua_with_ttl)
-        
+        if not self._smart_push_script:
+            raise RuntimeError(
+                "Lua scripts not initialized. Call init_scripts() first."
+            )
+
         try:
-            result = await script(keys=[list_key], args=[serialized_array, str(ttl)])
-            if result and len(result) == 2:
-                # result is a list of two string-serialized arrays
-                return [r.decode("utf-8") if isinstance(r, bytes) else r for r in result]
-            return None
-        except Exception as e:
-            logger.error(f"Error executing push_and_check_pairs Lua script: {e}")
-            raise
+            result = await self._smart_push_script(
+                keys=[list_key, arrived_key],
+                args=[serialized_array, str(ttl), str(expected_count)],
+            )
 
-# A global instance placeholder, needs to be initialized with the actual redis client in main.py or dependencies
-# redis_lua_manager = RedisLuaScripts(redis_client)
+            # result는 list[bytes] 형태
+            decoded = [r.decode("utf-8") if isinstance(r, bytes) else r for r in result]
+            action = decoded[0]
+            data = decoded[1:]
+            return action, data
+
+        except Exception as e:
+            logger.error(f"Error executing smart Lua script: {e}")
+            raise

--- a/ai_server/app/workers/challenge_feedback_worker.py
+++ b/ai_server/app/workers/challenge_feedback_worker.py
@@ -1,0 +1,246 @@
+"""
+Challenge Mode Feedback Worker (Phase 4: 설계.md 기반)
+
+AI_FEEDBACK_QUEUE 에서 개별 피드백 생성 작업을 소비합니다.
+- Rank 1: 솔로 모드 프롬프트로 단독 코칭 피드백 생성
+- Rank 2~N: PvP 모드 프롬프트로 1등과 비교 코칭 피드백 생성
+- 생성된 결과를 challenge:{id}:feedbacks Hash에 HSET으로 저장
+"""
+
+import json
+import random
+import logging
+from typing import Optional
+from aio_pika.abc import AbstractIncomingMessage
+
+from app.core.config import settings
+from app.core.prompts import (
+    BASE_SYSTEM_PROMPT,
+    PERSONA_PROMPTS,
+    PVP_SYSTEM_PROMPT,
+    PVP_PERSONA_PROMPTS,
+)
+from app.services.rabbitmq_service import rabbitmq_service
+import redis.asyncio as aioredis
+
+import google.generativeai as genai_standard
+
+logger = logging.getLogger("imyme-challenge-feedback-worker")
+
+# ── Global State ──
+redis_client: Optional[aioredis.Redis] = None
+
+# ── Rubric 로컬 메모리 캐시 (재사용) ──
+_rubric_cache: dict[str, str] = {}
+
+
+async def init_redis_for_feedback_worker():
+    global redis_client
+    if redis_client is None:
+        redis_client = await aioredis.from_url(settings.REDIS_URL)
+
+
+async def _get_rubric(knowledge_id: str) -> str:
+    """기준표를 로컬 캐시에서 읽고, 없으면 Redis에서 1회 조회 후 캐싱합니다."""
+    if knowledge_id in _rubric_cache:
+        return _rubric_cache[knowledge_id]
+
+    redis_key = f"knowledge:{knowledge_id}:rubric"
+    data = await redis_client.get(redis_key)
+    if data is None:
+        _rubric_cache[knowledge_id] = ""
+        return ""
+
+    rubric_text = data.decode("utf-8") if isinstance(data, bytes) else data
+    _rubric_cache[knowledge_id] = rubric_text
+    return rubric_text
+
+
+async def _get_participant_text(job_id: str, attempt_id: str) -> str:
+    """Redis Hash에서 특정 참가자의 STT 텍스트를 조회합니다."""
+    hash_key = f"challenge:{job_id}:participants"
+    raw = await redis_client.hget(hash_key, attempt_id)
+    if raw is None:
+        return ""
+    decoded = raw.decode("utf-8") if isinstance(raw, bytes) else raw
+    try:
+        parsed = json.loads(decoded)
+        return parsed.get("sttText", "")
+    except json.JSONDecodeError:
+        return decoded
+
+
+async def _generate_solo_feedback(criteria: str, user_text: str) -> dict:
+    """Solo 모드 프롬프트로 피드백을 생성합니다 (Rank 1 전용)."""
+    persona_key = random.choice(list(PERSONA_PROMPTS.keys()))
+    persona_instruction = PERSONA_PROMPTS[persona_key]
+
+    full_prompt = (
+        BASE_SYSTEM_PROMPT.format(
+            criteria=criteria,
+            user_text=user_text,
+            history="",  # 챌린지 모드에서는 학습 이력 없음
+        )
+        + persona_instruction
+    )
+
+    model = genai_standard.GenerativeModel("gemini-3-flash-preview")
+    response = await model.generate_content_async(full_prompt)
+
+    try:
+        text = response.text.strip()
+        # JSON 코드 블록 제거
+        if text.startswith("```"):
+            text = text.split("\n", 1)[1] if "\n" in text else text[3:]
+            if text.endswith("```"):
+                text = text[:-3]
+            text = text.strip()
+        return json.loads(text)
+    except (json.JSONDecodeError, AttributeError) as e:
+        logger.error(f"Failed to parse solo feedback JSON: {e}")
+        return {
+            "summary": "피드백 생성 중 오류가 발생했습니다.",
+            "keywords": [],
+            "facts": "",
+            "understanding": "",
+            "personalized_feedback": "",
+        }
+
+
+async def _generate_pvp_feedback(
+    criteria: str, top1_text: str, my_text: str, top1_id: str, my_id: str
+) -> dict:
+    """PvP 모드 프롬프트로 1등과 비교하는 피드백을 생성합니다 (Rank 2~N 전용)."""
+    strategy_key = random.choice(list(PVP_PERSONA_PROMPTS.keys()))
+    pvp_strategy = PVP_PERSONA_PROMPTS[strategy_key]
+
+    full_prompt = PVP_SYSTEM_PROMPT.format(
+        criteria=criteria,
+        user_a_id=top1_id,
+        user_a_text=top1_text,
+        user_b_id=my_id,
+        user_b_text=my_text,
+        pvp_strategy=pvp_strategy,
+    )
+
+    model = genai_standard.GenerativeModel("gemini-3-flash-preview")
+    response = await model.generate_content_async(full_prompt)
+
+    try:
+        text = response.text.strip()
+        if text.startswith("```"):
+            text = text.split("\n", 1)[1] if "\n" in text else text[3:]
+            if text.endswith("```"):
+                text = text[:-3]
+            text = text.strip()
+        parsed = json.loads(text)
+        # user_B 부분만 추출하여 반환 (현재 유저 = user_B)
+        return parsed.get("user_B", parsed)
+    except (json.JSONDecodeError, AttributeError) as e:
+        logger.error(f"Failed to parse PvP feedback JSON: {e}")
+        return {
+            "summary": "피드백 생성 중 오류가 발생했습니다.",
+            "keywords": [],
+            "facts": "",
+            "understanding": "",
+            "personalized_feedback": "",
+        }
+
+
+async def process_challenge_feedback(
+    body: dict, message: AbstractIncomingMessage
+) -> None:
+    """
+    AI_FEEDBACK_QUEUE 의 메시지를 처리하는 피드백 워커.
+
+    Payload:
+    {
+        "job_id": "uuid-...",
+        "knowledgeBase_id": "123",
+        "attemptId": "456",
+        "rank": 3,
+        "top1_id": "789",
+        "target_count": 100
+    }
+    """
+    job_id = body.get("job_id")
+    knowledge_id = body.get("knowledgeBase_id", "")
+    attempt_id = body.get("attemptId")
+    rank = body.get("rank", 0)
+    top1_id = body.get("top1_id", "")
+
+    if not all([job_id, attempt_id]):
+        logger.error(f"Invalid feedback payload: {body}")
+        return
+
+    logger.info(
+        f"Feedback Worker started for {job_id}, attemptId={attempt_id}, rank={rank}"
+    )
+
+    try:
+        # 1. 기준표 (Rubric) 캐시 로드
+        criteria = await _get_rubric(knowledge_id) if knowledge_id else ""
+
+        # 2. 내 텍스트 조회
+        my_text = await _get_participant_text(job_id, attempt_id)
+
+        # 3. 피드백 생성 분기
+        if rank == 1:
+            # 1등: Solo 모드 피드백
+            logger.info(f"🥇 Generating SOLO feedback for rank 1 ({attempt_id})")
+            feedback = await _generate_solo_feedback(criteria, my_text)
+        else:
+            # 2등 이하: PvP 모드 (1등과 비교)
+            top1_text = await _get_participant_text(job_id, top1_id)
+            logger.info(
+                f"🏅 Generating PvP feedback for rank {rank} ({attempt_id}) vs top1 ({top1_id})"
+            )
+            feedback = await _generate_pvp_feedback(
+                criteria, top1_text, my_text, top1_id, attempt_id
+            )
+
+        # 4. 결과 조립 및 Redis 저장
+        result = {
+            "attemptId": attempt_id,
+            "rank": rank,
+            **feedback,
+        }
+        feedback_hash_key = f"challenge:{job_id}:feedbacks"
+        await redis_client.hset(
+            feedback_hash_key, attempt_id, json.dumps(result, ensure_ascii=False)
+        )
+        # TTL 설정 (4시간)
+        await redis_client.expire(feedback_hash_key, 14400)
+
+        logger.info(
+            f"✅ Feedback saved for {attempt_id} (rank {rank}) -> {feedback_hash_key}"
+        )
+
+        # 5. 모든 피드백이 생성되었는지 확인 후 BE에 최종 알림
+        target_count = body.get("target_count")
+        if target_count:
+            fb_count = await redis_client.hlen(feedback_hash_key)
+            if fb_count >= target_count:
+                completed_msg = {"job_id": job_id, "status": "RANKING_COMPLETED"}
+                await rabbitmq_service.publish(
+                    settings.CHALLENGE_COMPLETED_QUEUE, completed_msg
+                )
+                logger.info(
+                    f"🎉 All {fb_count} feedbacks completed! Published to {settings.CHALLENGE_COMPLETED_QUEUE}"
+                )
+
+    except Exception as e:
+        logger.error(f"Error generating feedback for {attempt_id}: {e}")
+        raise
+
+
+async def start_challenge_feedback_consumer() -> None:
+    """main.py lifespan에서 호출되는 진입점."""
+    await init_redis_for_feedback_worker()
+    logger.info(
+        f"Starting Challenge Feedback Consumer on {settings.CHALLENGE_FEEDBACK_QUEUE}..."
+    )
+    await rabbitmq_service.consume(
+        queue_name=settings.CHALLENGE_FEEDBACK_QUEUE,
+        callback=process_challenge_feedback,
+    )

--- a/ai_server/app/workers/challenge_worker.py
+++ b/ai_server/app/workers/challenge_worker.py
@@ -1,0 +1,117 @@
+import json
+import logging
+from aio_pika.abc import AbstractIncomingMessage
+
+from app.core.config import settings
+from app.services.rabbitmq_service import rabbitmq_service
+from app.services.pairs_service import pairs_service
+from app.services.redis_lua_script import RedisLuaScripts
+# Assuming redis client init will be provided or injected. Here we mock a get_redis()
+import redis.asyncio as aioredis
+
+logger = logging.getLogger("imyme-challenge-worker")
+
+# Define global redis client 
+redis_client = None
+redis_lua = None
+
+async def init_redis_for_worker():
+    global redis_client, redis_lua
+    if redis_client is None:
+        redis_client = await aioredis.from_url(settings.REDIS_URL)
+        redis_lua = RedisLuaScripts(redis_client)
+        await redis_lua.init_scripts()
+
+async def process_challenge_evaluation(body: dict, message: AbstractIncomingMessage) -> None:
+    """
+    1. Receive {"job_id": "job:999", "level": L, "arr1": [...], "arr2": [...]}
+    2. Merge via PAIRS-beam.
+    3. Push to Redis level:L+1 using Lua Script.
+    4. If the script pops a new pair (length reached 2), publish it to MQ for level L+1.
+    5. If level:L+1 merged array length == 100, we're done! Publish completion.
+    """
+    job_id = body.get("job_id")
+    level = body.get("level")
+    arr1 = body.get("arr1")
+    arr2 = body.get("arr2")
+
+    if not all([job_id, level is not None, arr1, arr2]):
+        logger.error(f"Invalid challenge MQ payload: {body}")
+        return
+
+    logger.info(f"Challenge Worker started for {job_id} at Level {level}. Merging len {len(arr1)} and {len(arr2)}")
+
+    try:
+        # 1. Evaluate and Merge
+        merged_array = await pairs_service.merge_beam(arr1, arr2)
+        
+        # 2. Redis Push & Check Level Up (Atomic)
+        next_level = level + 1
+        redis_key = f"pairs:{job_id}:level:{next_level}"
+        
+        # TTL: 2 hours (7200s) infrastructure requirement
+        serialized = json.dumps(merged_array, ensure_ascii=False)
+        popped_pair = await redis_lua.push_and_check_pairs(redis_key, serialized, ttl=7200)
+
+        # 3. Handle Lua Script Result
+        if popped_pair and len(popped_pair) == 2:
+            new_arr1 = json.loads(popped_pair[0])
+            new_arr2 = json.loads(popped_pair[1])
+            
+            # Check for Final Completion (Length = 100)
+            # Actually, if we pop two arrays and their combined size config is 100 
+            # OR we just merged 100 and it's parked. Wait, the algorithm merges until 1 array of 100 is formed.
+            # If we merged them, and the result length is 100:
+            if len(new_arr1) + len(new_arr2) == 100:
+                 # It means we're about to merge the last two halves. We need to evaluate them first!
+                 # So we publish them to queue normally.
+                 pass
+                 
+        # Let's check completion right after merge before pushing, or check the merged_array length.
+        total_len = len(merged_array)
+        if total_len == 100:
+            logger.info(f"🏆 {job_id} ranking completed! Final length 100 reached.")
+            
+            # Save the final array to the final target key gracefully 
+            # (already pushed to level N, but lets mark a specific completed key)
+            final_key = f"pairs:{job_id}:completed"
+            await redis_client.set(final_key, serialized, ex=7200)
+            
+            # Publish bare-minimum completion message to MQ 
+            completion_msg = {
+                "job_id": job_id,
+                "status": "COMPLETED",
+                "redis_key": final_key
+            }
+            await rabbitmq_service.publish(settings.CHALLENGE_COMPLETED_QUEUE, completion_msg)
+            return
+
+        # Not complete 100 yet, if we got a pair from the same level, publish next mission
+        if popped_pair and len(popped_pair) == 2:
+             new_arr1 = json.loads(popped_pair[0])
+             new_arr2 = json.loads(popped_pair[1])
+             
+             next_mission = {
+                 "job_id": job_id,
+                 "level": next_level,
+                 "arr1": new_arr1,
+                 "arr2": new_arr2
+             }
+             logger.info(f"Level UP ⬆️ Publishing next match for {job_id} to Level {next_level} queue.")
+             await rabbitmq_service.publish(settings.CHALLENGE_EVAL_QUEUE, next_mission)
+
+    except Exception as e:
+        logger.error(f"Error resolving challenge merge for {job_id}: {e}")
+        raise
+
+async def start_challenge_consumer() -> None:
+    """
+    Start the RabbitMQ consumer for Challenge Mode.
+    Called from main.py lifespan.
+    """
+    await init_redis_for_worker()
+    logger.info("Starting Challenge MQ Consumer...")
+    await rabbitmq_service.consume(
+        queue_name=settings.CHALLENGE_EVAL_QUEUE,
+        callback=process_challenge_evaluation,
+    )

--- a/ai_server/app/workers/challenge_worker.py
+++ b/ai_server/app/workers/challenge_worker.py
@@ -1,19 +1,35 @@
+"""
+Challenge Mode Merge Worker (Phase 2: 설계.md 기반 리팩토링)
+
+AI_MERGE_QUEUE 에서 병합 작업을 소비합니다.
+1. Redis HMGET으로 텍스트 벌크 로드
+2. 기준표(Rubric) 로컬 캐싱 조회
+3. PAIRS-beam 정렬
+4. 스마트 Lua 스크립트로 결과 라우팅 (PAIR / PROMOTE / WAIT)
+5. 최종 랭킹 도달 시 Fan-out 피드백 발행
+"""
+
 import json
+import math
 import logging
+from typing import Optional
 from aio_pika.abc import AbstractIncomingMessage
 
 from app.core.config import settings
 from app.services.rabbitmq_service import rabbitmq_service
 from app.services.pairs_service import pairs_service
 from app.services.redis_lua_script import RedisLuaScripts
-# Assuming redis client init will be provided or injected. Here we mock a get_redis()
 import redis.asyncio as aioredis
 
 logger = logging.getLogger("imyme-challenge-worker")
 
-# Define global redis client 
-redis_client = None
-redis_lua = None
+# ── Global State ──
+redis_client: Optional[aioredis.Redis] = None
+redis_lua: Optional[RedisLuaScripts] = None
+
+# ── Rubric 로컬 메모리 캐시 (knowledge_id -> rubric text) ──
+_rubric_cache: dict[str, str] = {}
+
 
 async def init_redis_for_worker():
     global redis_client, redis_lua
@@ -22,96 +38,271 @@ async def init_redis_for_worker():
         redis_lua = RedisLuaScripts(redis_client)
         await redis_lua.init_scripts()
 
-async def process_challenge_evaluation(body: dict, message: AbstractIncomingMessage) -> None:
+
+async def _get_rubric(knowledge_id: str) -> str:
+    """기준표를 로컬 캐시에서 읽고, 없으면 Redis에서 1회 조회 후 캐싱합니다."""
+    if knowledge_id in _rubric_cache:
+        return _rubric_cache[knowledge_id]
+
+    redis_key = f"knowledge:{knowledge_id}:rubric"
+    data = await redis_client.get(redis_key)
+    if data is None:
+        logger.warning(f"Rubric not found in Redis for key: {redis_key}")
+        _rubric_cache[knowledge_id] = ""
+        return ""
+
+    rubric_text = data.decode("utf-8") if isinstance(data, bytes) else data
+    _rubric_cache[knowledge_id] = rubric_text
+    logger.info(f"Rubric cached for knowledge:{knowledge_id} (len={len(rubric_text)})")
+    return rubric_text
+
+
+async def _bulk_load_texts(job_id: str, id_list: list[str]) -> dict[str, str]:
     """
-    1. Receive {"job_id": "job:999", "level": L, "arr1": [...], "arr2": [...]}
-    2. Merge via PAIRS-beam.
-    3. Push to Redis level:L+1 using Lua Script.
-    4. If the script pops a new pair (length reached 2), publish it to MQ for level L+1.
-    5. If level:L+1 merged array length == 100, we're done! Publish completion.
+    Redis Hash에서 attemptId 리스트에 해당하는 텍스트를 한 번에 조회합니다.
+    Returns: {attemptId: sttText, ...}
+    """
+    hash_key = f"challenge:{job_id}:participants"
+    raw_list = await redis_client.hmget(hash_key, *id_list)
+    result = {}
+    for attempt_id, raw in zip(id_list, raw_list):
+        if raw:
+            decoded = raw.decode("utf-8") if isinstance(raw, bytes) else raw
+            try:
+                parsed = json.loads(decoded)
+                result[attempt_id] = parsed.get("sttText", "")
+            except json.JSONDecodeError:
+                result[attempt_id] = decoded
+        else:
+            logger.warning(f"No data for attemptId={attempt_id} in {hash_key}")
+            result[attempt_id] = ""
+    return result
+
+
+def _ids_to_items(id_list: list[str], text_map: dict[str, str]) -> list[dict]:
+    """attemptId 리스트를 PAIRS 서비스가 요구하는 {id, text} 딕셔너리 리스트로 변환."""
+    return [{"id": aid, "text": text_map.get(aid, "")} for aid in id_list]
+
+
+def _calc_expected_count(n: int) -> int:
+    """n개의 노드가 만드는 다음 레벨의 기대 노드 수. ceil(n/2)"""
+    return math.ceil(n / 2)
+
+
+async def process_challenge_merge(body: dict, message: AbstractIncomingMessage) -> None:
+    """
+    AI_MERGE_QUEUE 의 메시지를 처리하는 핵심 워커.
+
+    Payload:
+    {
+        "job_id": "uuid-...",
+        "knowledgeBase_id": "123",
+        "level": 0,
+        "array_a": ["attemptId_1"],
+        "array_b": ["attemptId_2"],
+        "target_count": 100,
+        "expected_count": 50      # 이 레벨에서 생겨야 할 노드 수
+    }
     """
     job_id = body.get("job_id")
+    knowledge_id = body.get("knowledgeBase_id", "")
     level = body.get("level")
-    arr1 = body.get("arr1")
-    arr2 = body.get("arr2")
+    arr_a_ids = body.get("array_a", [])
+    arr_b_ids = body.get("array_b", [])
+    target_count = body.get("target_count", 100)
+    expected_count = body.get("expected_count", 50)
 
-    if not all([job_id, level is not None, arr1, arr2]):
-        logger.error(f"Invalid challenge MQ payload: {body}")
+    if not all([job_id, level is not None, arr_a_ids, arr_b_ids]):
+        logger.error(f"Invalid challenge merge payload: {body}")
         return
 
-    logger.info(f"Challenge Worker started for {job_id} at Level {level}. Merging len {len(arr1)} and {len(arr2)}")
+    logger.info(
+        f"Merge Worker started for {job_id} at Level {level}. "
+        f"Merging {len(arr_a_ids)} vs {len(arr_b_ids)} (target={target_count})"
+    )
 
     try:
-        # 1. Evaluate and Merge
-        merged_array = await pairs_service.merge_beam(arr1, arr2)
-        
-        # 2. Redis Push & Check Level Up (Atomic)
-        next_level = level + 1
-        redis_key = f"pairs:{job_id}:level:{next_level}"
-        
-        # TTL: 2 hours (7200s) infrastructure requirement
-        serialized = json.dumps(merged_array, ensure_ascii=False)
-        popped_pair = await redis_lua.push_and_check_pairs(redis_key, serialized, ttl=7200)
+        # 1. 기준표 로컬 캐시 조회
+        criteria = await _get_rubric(knowledge_id) if knowledge_id else None
 
-        # 3. Handle Lua Script Result
-        if popped_pair and len(popped_pair) == 2:
-            new_arr1 = json.loads(popped_pair[0])
-            new_arr2 = json.loads(popped_pair[1])
-            
-            # Check for Final Completion (Length = 100)
-            # Actually, if we pop two arrays and their combined size config is 100 
-            # OR we just merged 100 and it's parked. Wait, the algorithm merges until 1 array of 100 is formed.
-            # If we merged them, and the result length is 100:
-            if len(new_arr1) + len(new_arr2) == 100:
-                 # It means we're about to merge the last two halves. We need to evaluate them first!
-                 # So we publish them to queue normally.
-                 pass
-                 
-        # Let's check completion right after merge before pushing, or check the merged_array length.
-        total_len = len(merged_array)
-        if total_len == 100:
-            logger.info(f"🏆 {job_id} ranking completed! Final length 100 reached.")
-            
-            # Save the final array to the final target key gracefully 
-            # (already pushed to level N, but lets mark a specific completed key)
-            final_key = f"pairs:{job_id}:completed"
-            await redis_client.set(final_key, serialized, ex=7200)
-            
-            # Publish bare-minimum completion message to MQ 
-            completion_msg = {
-                "job_id": job_id,
-                "status": "COMPLETED",
-                "redis_key": final_key
-            }
-            await rabbitmq_service.publish(settings.CHALLENGE_COMPLETED_QUEUE, completion_msg)
+        # 2. Redis Bulk Load: 모든 관련 ID의 텍스트를 한 번에 가져옴
+        all_ids = list(set(arr_a_ids + arr_b_ids))
+        text_map = await _bulk_load_texts(job_id, all_ids)
+
+        # 3. PAIRS-beam merge
+        items_a = _ids_to_items(arr_a_ids, text_map)
+        items_b = _ids_to_items(arr_b_ids, text_map)
+        merged_items = await pairs_service.merge_beam(items_a, items_b, criteria)
+
+        # 병합 결과는 ID 배열로 변환
+        merged_ids = [item["id"] for item in merged_items]
+
+        # 4. 최종 랭킹 체크 (루트 노드 도달?)
+        if len(merged_ids) >= target_count:
+            await _handle_ranking_complete(
+                job_id, knowledge_id, merged_ids, target_count
+            )
             return
 
-        # Not complete 100 yet, if we got a pair from the same level, publish next mission
-        if popped_pair and len(popped_pair) == 2:
-             new_arr1 = json.loads(popped_pair[0])
-             new_arr2 = json.loads(popped_pair[1])
-             
-             next_mission = {
-                 "job_id": job_id,
-                 "level": next_level,
-                 "arr1": new_arr1,
-                 "arr2": new_arr2
-             }
-             logger.info(f"Level UP ⬆️ Publishing next match for {job_id} to Level {next_level} queue.")
-             await rabbitmq_service.publish(settings.CHALLENGE_EVAL_QUEUE, next_mission)
+        # 5. Lua 스크립트로 다음 레벨에 Push & Route
+        next_level = level + 1
+        next_expected = _calc_expected_count(expected_count)
+        list_key = f"pairs:{job_id}:level:{next_level}"
+        arrived_key = f"pairs:{job_id}:level:{next_level}:arrived"
+        serialized = json.dumps(merged_ids, ensure_ascii=False)
+
+        action, data = await redis_lua.push_and_route(
+            list_key=list_key,
+            arrived_key=arrived_key,
+            serialized_array=serialized,
+            expected_count=next_expected,
+        )
+
+        if action == "PAIR":
+            new_arr_a = json.loads(data[0])
+            new_arr_b = json.loads(data[1])
+            next_mission = {
+                "job_id": job_id,
+                "knowledgeBase_id": knowledge_id,
+                "level": next_level,
+                "array_a": new_arr_a,
+                "array_b": new_arr_b,
+                "target_count": target_count,
+                "expected_count": next_expected,
+            }
+            logger.info(f"Level UP ⬆️ PAIR at Level {next_level} for {job_id}")
+            await rabbitmq_service.publish(settings.CHALLENGE_MERGE_QUEUE, next_mission)
+
+        elif action == "PROMOTE":
+            promoted_ids = json.loads(data[0])
+            logger.info(
+                f"🏅 PROMOTE (부전승) at Level {next_level} for {job_id}, "
+                f"promoting {len(promoted_ids)} IDs to next level"
+            )
+            # 부전승: 병합 없이 그대로 한 레벨 더 위로 올림
+            await _handle_promote(
+                job_id,
+                knowledge_id,
+                promoted_ids,
+                next_level,
+                next_expected,
+                target_count,
+            )
+
+        else:  # WAIT
+            logger.info(
+                f"⏳ WAIT at Level {next_level} for {job_id}. Waiting for pair."
+            )
 
     except Exception as e:
-        logger.error(f"Error resolving challenge merge for {job_id}: {e}")
+        logger.error(f"Error in challenge merge for {job_id}: {e}")
         raise
 
+
+async def _handle_promote(
+    job_id: str,
+    knowledge_id: str,
+    promoted_ids: list[str],
+    current_level: int,
+    current_expected: int,
+    target_count: int,
+):
+    """
+    부전승 노드를 한 레벨 위로 재귀적으로 올려보냅니다.
+    최종 목표에 도달하면 랭킹 완료 처리합니다.
+    """
+    if len(promoted_ids) >= target_count:
+        await _handle_ranking_complete(job_id, knowledge_id, promoted_ids, target_count)
+        return
+
+    upper_level = current_level + 1
+    upper_expected = _calc_expected_count(current_expected)
+    list_key = f"pairs:{job_id}:level:{upper_level}"
+    arrived_key = f"pairs:{job_id}:level:{upper_level}:arrived"
+    serialized = json.dumps(promoted_ids, ensure_ascii=False)
+
+    action, data = await redis_lua.push_and_route(
+        list_key=list_key,
+        arrived_key=arrived_key,
+        serialized_array=serialized,
+        expected_count=upper_expected,
+    )
+
+    if action == "PAIR":
+        new_arr_a = json.loads(data[0])
+        new_arr_b = json.loads(data[1])
+        next_mission = {
+            "job_id": job_id,
+            "knowledgeBase_id": knowledge_id,
+            "level": upper_level,
+            "array_a": new_arr_a,
+            "array_b": new_arr_b,
+            "target_count": target_count,
+            "expected_count": upper_expected,
+        }
+        logger.info(f"Level UP ⬆️ PAIR after PROMOTE at Level {upper_level}")
+        await rabbitmq_service.publish(settings.CHALLENGE_MERGE_QUEUE, next_mission)
+
+    elif action == "PROMOTE":
+        # 연쇄 부전승 → 재귀 호출
+        re_promoted = json.loads(data[0])
+        logger.info(f"🏅 Cascading PROMOTE at Level {upper_level}")
+        await _handle_promote(
+            job_id,
+            knowledge_id,
+            re_promoted,
+            upper_level,
+            upper_expected,
+            target_count,
+        )
+    else:
+        logger.info(f"⏳ WAIT after PROMOTE at Level {upper_level}")
+
+
+async def _handle_ranking_complete(
+    job_id: str, knowledge_id: str, final_ranking: list[str], target_count: int
+):
+    """
+    최종 랭킹이 완성되었을 때:
+    1. Redis에 최종 순위 저장
+    2. BE에 랭킹 완료 알림
+    3. Fan-out: 각 유저별 피드백 생성 메시지 발행
+    """
+    logger.info(f"🏆 {job_id} ranking completed! {len(final_ranking)} users ranked.")
+
+    # 1. Redis에 최종 순위 저장  (RPUSH challenge:{id}:final_ranking)
+    ranking_key = f"challenge:{job_id}:final_ranking"
+    pipe = redis_client.pipeline()
+    pipe.delete(ranking_key)
+    pipe.rpush(ranking_key, *final_ranking)
+    pipe.expire(ranking_key, 14400)  # 4시간 TTL
+    await pipe.execute()
+
+    # 2. Fan-out: 100(N)개의 피드백 생성 작업을 개별 MQ 메시지로 퍼블리시
+    top1_id = final_ranking[0]
+    for rank_idx, attempt_id in enumerate(final_ranking):
+        feedback_task = {
+            "job_id": job_id,
+            "knowledgeBase_id": knowledge_id,
+            "attemptId": attempt_id,
+            "rank": rank_idx + 1,  # 1-indexed
+            "top1_id": top1_id,
+            "target_count": target_count,
+        }
+        await rabbitmq_service.publish(settings.CHALLENGE_FEEDBACK_QUEUE, feedback_task)
+
+    logger.info(
+        f"📤 Published {len(final_ranking)} feedback tasks to {settings.CHALLENGE_FEEDBACK_QUEUE}"
+    )
+
+
 async def start_challenge_consumer() -> None:
-    """
-    Start the RabbitMQ consumer for Challenge Mode.
-    Called from main.py lifespan.
-    """
+    """main.py lifespan에서 호출되는 진입점."""
     await init_redis_for_worker()
-    logger.info("Starting Challenge MQ Consumer...")
+    logger.info(
+        f"Starting Challenge Merge Consumer on {settings.CHALLENGE_MERGE_QUEUE}..."
+    )
     await rabbitmq_service.consume(
-        queue_name=settings.CHALLENGE_EVAL_QUEUE,
-        callback=process_challenge_evaluation,
+        queue_name=settings.CHALLENGE_MERGE_QUEUE,
+        callback=process_challenge_merge,
     )

--- a/ai_server/requirements.txt
+++ b/ai_server/requirements.txt
@@ -20,3 +20,7 @@ tenacity>=8.2.0
 sqlalchemy>=2.0.0
 asyncpg>=0.29.0
 pgvector>=0.2.5
+
+# Challenge Mode Dependencies
+redis>=5.0.0
+google-genai>=0.2.0


### PR DESCRIPTION
## 📝 작업 배경 (Context)
- 기존 챌린지 모드는 참가자가 고정되어야 했고, 단순 텍스트 비교 구조로 인해 다수 참가자에 대한 연산 병목 및 평가의 정확도 이슈가 존재했습니다.
- 이를 해결하기 위해 **지식 기반(Criteria) PAIRS 알고리즘 도입**, **참가자 동적 지원 및 홀수 부전승 레이어 구현**, **피드백 생성 병렬화(Fan-out)**를 도입하여 대규모 챌린지에도 즉각적으로 대응할 수 있는 아키텍처로 전면 개편했습니다.

## 🚀 주요 변경 사항 (Key Changes)

### 1. 🏅 동적 인원 및 부전승(Promote) 알고리즘 적용
- `redis_lua_script`: 참가 인원이 100명이 아니거나, 특정 레벨에서 홀수 개의 노드가 발생할 경우 마지막 노드를 병합 없이 다음 레벨로 자동 승급(부전승)시키는 원자적(Atomic) **3상태(PAIR, PROMOTE, WAIT) 스마트 Lua 스크립트**를 도입했습니다.

### 2. ⚡️ 피드백 생성 분산 처리 (Fan-out Pattern)
- `challenge_worker`: 트리의 루트(최종 랭킹) 도달 시, 전체 순위를 확정하고 N명의 유저에게 **개별 피드백 생성 작업을 MQ(`q.challenge.feedback`)로 병렬 발행(Fan-out)** 합니다.
- `challenge_feedback_worker` 신설:
  - **1등**: Solo 모드 프롬프트를 이용한 단독 칭찬/코칭 피드백 생성
  - **2~N등**: 1등의 답변과 자신의 답변을 비교 분석하는 PvP 모드 피드백 생성
- 모든 생성된 피드백은 Redis Hash(`challenge:{id}:feedbacks`)에 저장됩니다.

### 3. 🧠 지식 기반(Knowledge-based) 정밀 비교
- `prompts` & `pairs_service`: 두 답변을 무작위로 비교하던 방식에서 벗어나, 페이로드의 `knowledgeBase_id`를 기반으로 얻은 **채점 기준표(Rubric)**를 LLM에 주입하여 `Keyword Coverage`, `Factual Accuracy`, `Depth` 기준으로 객관적인 승패(1 or 2)를 가리도록 프롬프트를 고도화했습니다.

### 4. 🗄️ 백엔드(BE) 통신 스펙 완벽 정렬 및 성능 최적화
- **최종 완료 알림**: 모든 N명의 피드백 결과가 Redis에 100% 저장 완료된 직후 단 한 번, BE 서버가 즉시 데이터를 읽어갈 수 있도록 **`challenge.final.done`** 큐에 `{job_id, status: RANKING_COMPLETED}` 알림을 발송합니다.
- **조회 병목 해소**: 
  - 병합 전 원본 텍스트 조회를 위해 Redis `HMGET`을 사용한 Bulk-Load 적용 (N+1 문제 해결)
  - 기준표(Rubric) 데이터 조회를 위한 파이썬 내부 메모리 캐싱 적용

### 5. 🛠️ 코드 리팩터링 및 모델 최신화
- AI 코어 서비스 전반 모델을 `gemini-3-flash-preview`로 통합 업그레이드
- 전체 파이썬 파일 `Ruff` 포매터 적용 및 컨벤션 정리

## 🤝 리뷰어 참고 사항 (To Reviewers)
- BE 팀에서는 챌린지 모드 큐 발화 시 `target_count`(총 참가자 수)와 [expected_count](cci:1://file:///Users/sincheol/STT-FineTuning/4-team-IMYME-ai/ai_server/app/workers/challenge_worker.py:86:0-88:27)(총 참가자 수와 동일) 파라미터를 Payload에 반드시 포함해 주시면 됩니다. (부전승 계산용)
- 최종 완료 메시지가 `challenge.final.done` 큐로 날아오면, `LRANGE challenge:{id}:final_ranking` 과 `HGETALL challenge:{id}:feedbacks` 로 즉시 렌더링 응답을 주시면 됩니다!