### PR TITLE
test: add comprehensive pytest suite for all workers and services

### DIFF
--- a/ai_server/app/services/rabbitmq_service.py
+++ b/ai_server/app/services/rabbitmq_service.py
@@ -58,7 +58,11 @@ class RabbitMQService:
         """Return the correct exchange based on queue name prefix or contained sub-string."""
         if "solo" in queue_name:
             return self.solo_exchange
-        if "pairs" in queue_name or "ranking" in queue_name:
+        if (
+            "challenge" in queue_name
+            or "pairs" in queue_name
+            or "ranking" in queue_name
+        ):
             return self.challenge_exchange
         return self.pvp_exchange
 
@@ -66,7 +70,11 @@ class RabbitMQService:
         """Return the correct DLQ name based on queue name prefix."""
         if queue_name.startswith("solo."):
             return settings.SOLO_DLQ
-        if "pairs" in queue_name or "ranking" in queue_name:
+        if (
+            "challenge" in queue_name
+            or "pairs" in queue_name
+            or "ranking" in queue_name
+        ):
             return settings.CHALLENGE_DLQ
         return settings.PVP_DLQ
 


### PR DESCRIPTION
## 🌟 배경 및 목적 (Background & Objective)
- 기존 AI 서버(app/workers, app/services)에 대한 테스트 코드가 부재하여 유지보수성과 CI/CD 파이프라인 연동을 위한 테스트 커버리지 확보가 필요했습니다.
- [Hotfix] 챌린지 모드 큐가 PvP 익스체인지(`pvp.direct`)로 잘못 라우팅되는 크리티컬한 버그가 발견되어 이를 수정했습니다.

## 🛠 주요 변경 사항 (Key Changes)
1. **RabbitMQ 라우팅 버그 핫픽스**
   - [rabbitmq_service.py](cci:7://file:///Users/sincheol/STT-FineTuning/4-team-IMYME-ai/ai_server/app/services/rabbitmq_service.py:0:0-0:0) 내의 [_get_exchange](cci:1://file:///Users/sincheol/STT-FineTuning/4-team-IMYME-ai/ai_server/app/services/rabbitmq_service.py:56:4-62:32) 및 [_get_dlq](cci:1://file:///Users/sincheol/STT-FineTuning/4-team-IMYME-ai/ai_server/app/services/rabbitmq_service.py:64:4-70:31) 로직이 "challenge" 키워드를 잡아내어 올바르게 `challenge.direct`로 라우팅하도록 수정했습니다.

## ⚠️ 리뷰어 필수 확인 사항 (Reviewer Notes)
- **[서버 관리자 확인 요망]** RabbitMQ 서버 내에 과거 배포로 인해 DLX가 없이 생성된 기존 챌린지 관련 큐(`challenge.pairs.eval` 등)가 남아 있습니다. AI 서버가 배포될 때 충돌(PRECONDITION_FAILED)을 방지하기 위해 Management UI/CLI를 통해 기존 큐 삭제 1회를 선행해 주시기 바랍니다.
