### PR TITLE
feat: enable per-consumer prefetch for parallel RabbitMQ message proc…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ build/
 
 # Tests
 tests/
+pytest.ini

--- a/ai_server/app/services/rabbitmq_service.py
+++ b/ai_server/app/services/rabbitmq_service.py
@@ -5,7 +5,7 @@ Provides asynchronous message queue communication using aio-pika's RobustConnect
 for automatic reconnection on network failures.
 
 Key features:
-- QoS (prefetch_count=1): Sequential processing, one message at a time per worker.
+- QoS (prefetch_count=6): Sequential processing, one message at a time per worker.
 - Manual Ack/Nack: Messages are acknowledged only after successful processing.
 - 3-Retry with DLQ: Failed messages are retried up to 3 times via a TTL-based
   retry queue. On the 3rd failure, a FAIL response is published to the result
@@ -89,8 +89,9 @@ class RabbitMQService:
         self.connection = await aio_pika.connect_robust(settings.RABBITMQ_URL)
         self.channel = await self.connection.channel()
 
-        # QoS: process one message at a time per worker (sequential guarantee)
-        await self.channel.set_qos(prefetch_count=1)
+        # QoS will be set per-consumer in consume() to fine-tune parallelism
+        # (STT workers → prefetch=6 to match RunPod capacity;
+        #  Feedback/Merge workers → prefetch=6 for Gemini-backed parallelism)
 
         # Declare Direct Exchange (durable: survives server restart)
         self.pvp_exchange = await self.channel.declare_exchange(
@@ -203,6 +204,15 @@ class RabbitMQService:
             callback: Message processing callback (parsed_body, raw_message)
         """
         queue = await self.declare_and_bind_queue(queue_name)
+
+        # Per-consumer prefetch tuning:
+        #   STT queues   → prefetch=6
+        #   Other queues → prefetch=6  (Gemini-backed; no RunPod cap)
+        is_stt_queue = queue_name.endswith(".stt.request") or (
+            queue_name.endswith(".feedback.request") and "challenge" in queue_name
+        )
+        prefetch = 6 if is_stt_queue else 6
+        await queue.channel.set_qos(prefetch_count=prefetch)
 
         # Determine the response queue for publishing FAIL on final failure
         response_queue = REQUEST_TO_RESPONSE_QUEUE.get(queue_name)


### PR DESCRIPTION
## 🌟 배경 (Background)
기존 rabbitmq_service.py의 `prefetch_count=1` 글로벌 설정으로 인해 
모든 워커가 메시지를 **한 번에 1건씩만 순차적으로** 처리하고 있었습니다.

Solo/PvP/Challenge STT 워커가 각각 독립적으로 실행됨에도 불구하고,
RunPod에 동시에 1개의 요청만 전달되어 **6개의 RunPod Serverless 워커가 
전혀 활용되지 못하는 병목 현상**이 존재했습니다.

## 🛠 변경 사항
- **채널 레벨 글로벌 QoS 제거**: `channel.set_qos(prefetch_count=1)` 삭제
- **컨슈머 레벨 per-consumer prefetch 도입**: [consume()](cci:1://file:///Users/sincheol/STT-FineTuning/4-team-IMYME-ai/ai_server/app/services/rabbitmq_service.py:183:4-320:61) 메서드 내에서 
  `queue.channel.set_qos(prefetch_count=6)` 설정
- 각 워커가 큐에서 최대 6개의 메시지를 동시에 꺼내어 병렬 처리 가능

## ✅ 기대 효과
- 여러 유저가 동시에 STT를 요청할 때 RunPod 워커를 최대 활용 가능
- 처리 지연(Latency) 감소 및 처리량(Throughput) 향상
- Solo/PvP/Challenge 큐별로 독립적인 병렬 처리 보장

## ⚠️ 리뷰어 확인 사항
- RunPod Serverless max_workers 설정과 prefetch 값을 함께 조율해야 합니다.

