### PR TITLE
fix(auth): Enable Vertex AI auth via service account JSON string

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -878,3 +878,22 @@ if not all(
 ### 29.4. 교훈 (Lesson Learned)
 - 마이크로서비스(Spring ↔ Python Worker) 분리 환경에서는 **메시지 큐(MQ) 통신 포맷뿐만 아니라, 양쪽이 공유하는 Redis 스토리지의 입출력 JSON 직렬화 스키마(Schema)까지 완벽히 문서화하고 합의**해야 함.
 - TDD(단위 테스트)를 짤 때 역시, 내부 로직의 정상 동작 여부만 검증(`assert "summary" in parsed`)할 것이 아니라, 외부 인터페이스 스펙(계약, Contract) 자체를 Mock 데이터와 Asserion 코드에 반영하는 "계약 주도 테스트"가 필요함을 깨달음.
+
+## 30. Vertex AI 인증 오류 (Application Default Credentials Not Found) [2026-03-22]
+
+### 30.1. 문제 상황 (Problem)
+- **증상**: 챌린지 모드 병합 워커(`challenge.pairs.eval`) 실행 시, LLM 비교 호출 단계에서 `Your default credentials were not found` 에러가 발생하며 프로세스가 중단됨.
+- **영향**: PAIRS 알고리즘 기반의 지식 비교 연산이 불가능해져, 챌린지 랭킹 산출 전체 프로세스가 멈추는 치명적 장애 발생.
+
+### 30.2. 원인 분석 (Root Cause)
+- `app/services/pairs_service.py`에서 구글의 새로운 `google-genai` SDK를 사용하면서 `vertexai=True` 옵션을 활성화함.
+- **Vertex AI 모드**는 단순 API Key가 아닌 GCP의 **ADC(Application Default Credentials)** 인증 체계를 강제함. 배포 환경이나 로컬 환경에 `gcloud` 로그인 정보 또는 서비스 계정 키 파일(`JSON`)이 설정되어 있지 않아 인증에 실패함.
+
+### 30.3. 해결 방법 (Solution)
+- 일반적인 로컬 개발 환경이나 단순 배포 환경 편의성을 위해 API Key 방식으로도 대응 가능하나, **보안 정책상 Vertex AI를 필수 사용해야 하는 엔터프라이즈 환경**에서는 서비스 계정(Service Account)키 파일 연동이 제한될 수 있음 (컨테이너 내 키 파일 물리적 보관 금지 등).
+- 이를 해결하기 위해 AWS Parameter Store나 환경 변수에서 JSON 평문을 직접 통째로 문자열(`GCP_SA_JSON_STR`)로 긁어오도록 로직 아키텍처를 전면 개편함.
+- `app/services/pairs_service.py` 내의 클라이언트 초기화 로직에서 `service_account.Credentials.from_service_account_info(sa_info)`를 사용해, 물리적 파일 경로 지정(`GOOGLE_APPLICATION_CREDENTIALS`) 규제를 우회하고 메모리 상에서 즉석으로 ADC 인증을 통과시킴.
+
+### 30.4. 교훈 (Lesson Learned)
+- **Fileless 런타임 보안 아키텍처**: 클라우드 SDK 기본값은 주로 `File` 경로 접근을 유도하지만, 모던 컨테이너/클라우드 환경에서는 기밀 정보를 파일로 저장하는 것이 큰 안티패턴(Anti-pattern)이 될 수 있음.
+- 따라서 Google Cloud 라이브러리가 지원하는 메모리 인증 방식(`from_service_account_info`)을 적극 발굴/활용해, DevOps(CLOUD) 팀의 보안 기준을 충족하면서 파라미터 스토어와 완벽하게 연동되는 백엔드 시스템을 설계해야 함.

--- a/ai_server/app/core/config.py
+++ b/ai_server/app/core/config.py
@@ -74,6 +74,7 @@ class Settings(BaseSettings):
     GCP_PROJECT: str = ""
     GCP_LOCATION: str = ""
     PAIRS_MODEL_ID: str = ""
+    GCP_SA_JSON_STR: str = ""
 
     class Config:
         # Load settings from .env file if present

--- a/ai_server/app/services/pairs_service.py
+++ b/ai_server/app/services/pairs_service.py
@@ -7,10 +7,12 @@ Logprob + 위치 편향 보정 + Uncertainty-Guided Beam Search 를 수행합니
 
 import math
 import asyncio
+import json
 import logging
 from typing import List, Tuple, Optional
 from google import genai
 from google.genai import types
+from google.oauth2 import service_account
 from tenacity import retry, wait_exponential, stop_after_attempt
 
 from app.core.config import settings
@@ -18,15 +20,32 @@ from app.core.prompts import CHALLENGE_PAIRS_SYSTEM_PROMPT, CHALLENGE_PAIRS_USER
 
 logger = logging.getLogger("imyme-pairs-service")
 
-# ── Vertex AI Client 초기화 ──
+# ── Vertex AI Client 초기화 (Parameter Store JSON 직접 읽기) ──
 try:
-    client = genai.Client(
-        vertexai=True,
-        project=settings.GCP_PROJECT,
-        location=settings.GCP_LOCATION,
-    )
+    gcp_json_str = settings.GCP_SA_JSON_STR
+    if gcp_json_str:
+        sa_info = json.loads(gcp_json_str)
+        credentials = service_account.Credentials.from_service_account_info(
+            sa_info, scopes=["https://www.googleapis.com/auth/cloud-platform"]
+        )
+        client = genai.Client(
+            vertexai=True,
+            project=settings.GCP_PROJECT,
+            location=settings.GCP_LOCATION,
+            credentials=credentials,
+        )
+        logger.info(
+            "Successfully initialized Vertex AI client using Service Account JSON String."
+        )
+    else:
+        logger.info("GCP_SA_JSON_STR not found. Falling back to default ADC.")
+        client = genai.Client(
+            vertexai=True,
+            project=settings.GCP_PROJECT,
+            location=settings.GCP_LOCATION,
+        )
 except Exception as e:
-    logger.warning(f"Failed to initialize Vertex AI client: {e}")
+    logger.error(f"Failed to initialize Vertex AI client: {e}")
     client = genai.Client()
 
 RESPONSE_SCHEMA = {"type": "STRING", "enum": ["1", "2"]}


### PR DESCRIPTION
## 🚀 개요
본 PR은 챌린지 모드 병합 큐(`challenge.pairs.eval`) 처리 중 발생하던 **Vertex AI 인증 오류(`Your default credentials were not found`)를 물리적인 키 파일(File-based) 배포 없이 안전하게 해결**합니다.

엔터프라이즈 환경에서의 컨테이너 보안 정책상, GCP 서비스 계정(`JSON`) 키 파일을 도커 이미지나 실행 환경에 물리적으로 거치하는 것은 보안 취약점이 될 수 있습니다. 이에 AWS 파라미터 스토어에 입력된 "JSON 평문 문자열" 자체를 환경변수로 주입받아 **메모리(In-Memory) 상에서 즉석 인증**을 수행하도록 아키텍처를 개편했습니다.

## 🛠️ 주요 변경 사항
- **환경 변수 스키마 추가 ([app/core/config.py](cci:7://file:///Users/sincheol/STT-FineTuning/4-team-IMYME-ai/ai_server/app/core/config.py:0:0-0:0))**:
  - `GCP_SA_JSON_STR` 변수를 추가하여 클라우드 파라미터 스토어 데이터 주입 통로 개설
- **Fileless 인증 객체 주입 ([app/services/pairs_service.py](cci:7://file:///Users/sincheol/STT-FineTuning/4-team-IMYME-ai/ai_server/app/services/pairs_service.py:0:0-0:0))**:
  - `service_account.Credentials.from_service_account_info()` 함수를 사용해 환경 변수로 주입된 JSON 텍스트를 파싱하여 인증 객체 생성
  - 파일 우회 인증 시 누락되는 Google SDK의 기본 백그라운드 스코프 문제를 해결하기 위해, 객체 생성단에 `scopes=["https://www.googleapis.com/auth/cloud-platform"]` 명시적 주입 완료
- **로컬 Fallback 처리**:
  - 해당 환경 변수가 선언되지 않은 로컬 작업자 PC의 경우, 원래대로 `genai.Client(vertexai=True)`를 실행하여 로컬 `gcloud` 세션을 그대로 활용할 수 있도록 호환성 유지

## 📌 CLOUD/DevOps 팀 확인 사항
서버(RunPod 등) 배포 시뮬레이션 및 런타임 환경 구성 시:
1. 구글 클라우드에서 발급받은 서비스 계정(Vertex AI 사용자 권한)의 Key `.json` 파일을 여시고,
2. 안의 모든 코드를 복사하여 **`GCP_SA_JSON_STR`** 이라는 이름의 파라미터 스토어(또는 시스템 환경변수) 한 줄짜리 String Value로 등록해 주시기 바랍니다.

## 💡 레퍼런스 및 기타
- 관련 에러 히스토리 및 트러블슈팅 내역은 [TROUBLESHOOTING.md](cci:7://file:///Users/sincheol/STT-FineTuning/4-team-IMYME-ai/TROUBLESHOOTING.md:0:0-0:0)의 [30. Vertex AI 인증 오류] 항목에 상세 기록해 두었습니다!
