### PR TITLE
feat: implement short-text defense logic in challenge feedback worker

### DIFF
--- a/ai_server/app/workers/challenge_feedback_worker.py
+++ b/ai_server/app/workers/challenge_feedback_worker.py
@@ -27,6 +27,11 @@ import google.generativeai as genai_standard
 
 logger = logging.getLogger("imyme-challenge-feedback-worker")
 
+# ── 짧은 텍스트(기권) 방어 상수 (pvp_feedback_service.py와 동일) ──
+MIN_TEXT_LENGTH = 5
+FORFEIT_PLACEHOLDER = "(답변을 제출하지 않아 기권 처리되었습니다.)"
+DRAW_MSG = "모든 유저의 내용이 부족하여 피드백을 할 수 없습니다."
+
 # ── Global State ──
 redis_client: Optional[aioredis.Redis] = None
 
@@ -68,6 +73,17 @@ async def _get_participant_data(job_id: str, attempt_id: str) -> dict:
         return {"userId": parsed.get("userId"), "sttText": parsed.get("sttText", "")}
     except json.JSONDecodeError:
         return {"userId": None, "sttText": decoded}
+
+
+def _hardcoded_feedback(msg: str) -> dict:
+    """LLM 호출 없이 즉시 반환할 하드코딩 피드백을 생성합니다."""
+    return {
+        "summary": msg,
+        "keywords": [],
+        "facts": msg,
+        "understanding": msg,
+        "personalized_feedback": msg,
+    }
 
 
 async def _generate_solo_feedback(criteria: str, user_text: str) -> dict:
@@ -186,21 +202,51 @@ async def process_challenge_feedback(
         my_text = my_data["sttText"]
         my_user_id = my_data["userId"]
 
-        # 3. 피드백 생성 분기
+        # 3. 짧은 텍스트 검사 (PvP와 동일한 기권 방어 로직)
+        my_short = len(my_text.strip()) < MIN_TEXT_LENGTH
+
         if rank == 1:
-            # 1등: Solo 모드 피드백
-            logger.info(f"🥇 Generating SOLO feedback for rank 1 ({attempt_id})")
-            feedback = await _generate_solo_feedback(criteria, my_text)
+            # ── 1등: Solo 모드 피드백 ──
+            if my_short:
+                logger.info(
+                    f"⏭️ Rank 1 short text ({len(my_text.strip())} chars). "
+                    f"Returning hardcoded feedback for {attempt_id}"
+                )
+                feedback = _hardcoded_feedback(DRAW_MSG)
+            else:
+                logger.info(f"🥇 Generating SOLO feedback for rank 1 ({attempt_id})")
+                feedback = await _generate_solo_feedback(criteria, my_text)
         else:
-            # 2등 이하: PvP 모드 (1등과 비교)
+            # ── 2등 이하: PvP 모드 (1등과 비교) ──
             top1_data = await _get_participant_data(job_id, top1_id)
             top1_text = top1_data["sttText"]
-            logger.info(
-                f"🏅 Generating PvP feedback for rank {rank} ({attempt_id}) vs top1 ({top1_id})"
-            )
-            feedback = await _generate_pvp_feedback(
-                criteria, top1_text, my_text, top1_id, attempt_id
-            )
+            top1_short = len(top1_text.strip()) < MIN_TEXT_LENGTH
+
+            if top1_short:
+                # Case 1/3: 1등이 짧으면 비교 자체가 불가능 → 하드코딩
+                logger.info(
+                    f"⏭️ Top1 ({top1_id}) text too short ({len(top1_text.strip())} chars). "
+                    f"Cannot compare. Hardcoded feedback for {attempt_id}"
+                )
+                feedback = _hardcoded_feedback(DRAW_MSG)
+            elif my_short:
+                # Case 2: 나만 짧음 → 기권 처리 문구로 치환 후 LLM 비교
+                logger.info(
+                    f"⏭️ My text too short ({len(my_text.strip())} chars). "
+                    f"Replacing with forfeit placeholder for {attempt_id}"
+                )
+                my_text = FORFEIT_PLACEHOLDER
+                feedback = await _generate_pvp_feedback(
+                    criteria, top1_text, my_text, top1_id, attempt_id
+                )
+            else:
+                # Case 4: 둘 다 정상 길이 → 정상 PvP 비교
+                logger.info(
+                    f"🏅 Generating PvP feedback for rank {rank} ({attempt_id}) vs top1 ({top1_id})"
+                )
+                feedback = await _generate_pvp_feedback(
+                    criteria, top1_text, my_text, top1_id, attempt_id
+                )
 
         # 4. 결과 조립 및 Redis 저장 (BE 명세에 맞는 구조)
         result = {


### PR DESCRIPTION
## 🚀 챌린지 모드 피드백 생성 로직 개선 업데이트

### 1. 📝 개요
챌린지 모드 피드백 생성 시, 내용이 너무 짧거나 없는 답변(STT 오류 포함)에 대해 불필요한 LLM 호출을 방지하고 정확한 기권 처리를 수행하도록 로직을 개선했습니다. 기존 PvP 모드의 방어 로직을 챌린지 워커 구조에 맞게 성공적으로 이식했습니다.

### 2. ⚙️ 주요 변경 사항

* **기권 판정 기준 도입**
  * `MIN_TEXT_LENGTH = 5` 기준을 적용하여, 5자 미만 답변 시 기권으로 처리합니다.

* **포맷팅 상수 정의**
  * `FORFEIT_PLACEHOLDER`: 기권자의 텍스트를 대체할 문구 ("(답변을 제출하지 않아...)")
  * `DRAW_MSG`: 비교가 불가능할 때 반환되는 하드코딩 메시지 ("모든 유저의 내용이 부족하여...")

* **순위별 분기 로직 정교화**
  * **Rank 1 (우승자):** 본인의 답변이 짧을 경우, 즉시 하드코딩된 피드백을 리턴합니다.
  * **Rank N (도전자 vs 우승자):**
    * **우승자의 답변이 짧은 경우:** 비교 불가 상태로 판단하여 즉시 하드코딩 피드백을 리턴합니다.
    * **도전자(본인)의 답변만 짧은 경우:** 도전자의 답변을 기권 문구(`FORFEIT_PLACEHOLDER`)로 치환한 후 우승자와 PvP 비교를 수행하여, 우승자의 우위를 확정하고 피드백을 생성합니다.
    * **정상 케이스:** 기존과 동일하게 Gemini LLM을 활용하여 상세 비교 피드백을 생성합니다.

* **코드 모듈화**
  * 반복적인 하드코딩 JSON 생성을 처리하기 위해 `_hardcoded_feedback` 헬퍼 함수를 추가했습니다.

### 3. ✨ 기대 효과
* 의미 없는 짧은 답변에 대한 **Gemini API 토큰 비용 절감** 및 **응답 속도 향상**.
* 입력 데이터 부족으로 인해 발생할 수 있는 **LLM의 환각(Hallucination) 현상** 및 **JSON 파싱 에러 원천 차단**.
* 전체 서비스(Solo / PvP / Challenge) 전반에 걸친 **예외 처리 로직의 일관성 확보**.

### 4. ✅ 테스트 결과
* `py_compile`을 통한 문법 검증 완료.
* 기존 Unit Test(`test_challenge_feedback_worker.py`) 환경에서의 Mock 데이터 호환성 정상 확인.
