### PR TITLE
Fix/challenge no answer feedback format

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ cd 4-team-IMYME-ai
 # 가상환경 생성 및 의존성 설치
 python -m venv venv
 source venv/bin/activate
-pip install -r requirements.txt
+pip install -r ai_server/requirements.txt
 ```
 
 ### 2. Configuration (.env)

--- a/ai_server/app/core/prompts.py
+++ b/ai_server/app/core/prompts.py
@@ -283,12 +283,6 @@ CHALLENGE_PAIRS_SYSTEM_PROMPT = """You are an expert technical evaluator for com
 You will receive a grading rubric (Criteria) and two user answers to the same question.
 Your task is to determine which answer demonstrates better understanding based on the rubric.
 
-AUTOMATIC LOSS RULE (highest priority, checked before all else):
-- If an answer is "[NO_ANSWER]" or is completely empty, that answer automatically loses.
-- If Answer 1 is "[NO_ANSWER]", respond with "2" immediately.
-- If Answer 2 is "[NO_ANSWER]", respond with "1" immediately.
-- If both answers are "[NO_ANSWER]", respond with "2" (arbitrary tiebreak).
-
 EVALUATION CRITERIA (in order of importance):
 1. Keyword Coverage (40%): Which answer includes more of the required keywords from the rubric?
 2. Factual Accuracy (40%): Which answer aligns better with the rubric's technical content?

--- a/ai_server/app/core/prompts.py
+++ b/ai_server/app/core/prompts.py
@@ -283,6 +283,12 @@ CHALLENGE_PAIRS_SYSTEM_PROMPT = """You are an expert technical evaluator for com
 You will receive a grading rubric (Criteria) and two user answers to the same question.
 Your task is to determine which answer demonstrates better understanding based on the rubric.
 
+AUTOMATIC LOSS RULE (highest priority, checked before all else):
+- If an answer is "[NO_ANSWER]" or is completely empty, that answer automatically loses.
+- If Answer 1 is "[NO_ANSWER]", respond with "2" immediately.
+- If Answer 2 is "[NO_ANSWER]", respond with "1" immediately.
+- If both answers are "[NO_ANSWER]", respond with "2" (arbitrary tiebreak).
+
 EVALUATION CRITERIA (in order of importance):
 1. Keyword Coverage (40%): Which answer includes more of the required keywords from the rubric?
 2. Factual Accuracy (40%): Which answer aligns better with the rubric's technical content?

--- a/ai_server/app/services/pairs_service.py
+++ b/ai_server/app/services/pairs_service.py
@@ -155,17 +155,22 @@ class PairsService:
         text_a = item_a["text"]
         text_b = item_b["text"]
 
-        # ── 짧은 텍스트 즉시 패배 처리 (LLM 호출 없이 기권 패널티 적용) ──
+        # ── 짧은 텍스트 / 무발화 즉시 패배 처리 (LLM 호출 없이 기권 패널티 적용) ──
         MIN_TEXT_LENGTH = 5
-        a_short = len(text_a.strip()) < MIN_TEXT_LENGTH
-        b_short = len(text_b.strip()) < MIN_TEXT_LENGTH
+        NO_ANSWER_MARKER = "[NO_ANSWER]"
+        a_short = (
+            len(text_a.strip()) < MIN_TEXT_LENGTH or text_a.strip() == NO_ANSWER_MARKER
+        )
+        b_short = (
+            len(text_b.strip()) < MIN_TEXT_LENGTH or text_b.strip() == NO_ANSWER_MARKER
+        )
 
         if a_short and b_short:
-            # 둘 다 짧음: 무승부 (0.5, 0.5), entropy=0 (확정)
+            # 둘 다 짧음: A 승리 (임의 타이브레이크)
             logger.info(
-                f"⏭️ Both texts too short for PAIRS compare (A={len(text_a.strip())}, B={len(text_b.strip())} chars). Treating as draw."
+                f"⏭️ Both texts too short for PAIRS compare (A={len(text_a.strip())}, B={len(text_b.strip())} chars). A wins by tiebreak."
             )
-            return 0.5, 0.5, 0.0
+            return 1.0, 0.0, 0.0
         if a_short:
             # A만 짧음: B 무조건 승리
             logger.info(

--- a/ai_server/app/services/pairs_service.py
+++ b/ai_server/app/services/pairs_service.py
@@ -154,6 +154,31 @@ class PairsService:
         """위치 편향 보정된 쌍방향 비교. criteria가 있으면 지식 기반 비교."""
         text_a = item_a["text"]
         text_b = item_b["text"]
+
+        # ── 짧은 텍스트 즉시 패배 처리 (LLM 호출 없이 기권 패널티 적용) ──
+        MIN_TEXT_LENGTH = 5
+        a_short = len(text_a.strip()) < MIN_TEXT_LENGTH
+        b_short = len(text_b.strip()) < MIN_TEXT_LENGTH
+
+        if a_short and b_short:
+            # 둘 다 짧음: 무승부 (0.5, 0.5), entropy=0 (확정)
+            logger.info(
+                f"⏭️ Both texts too short for PAIRS compare (A={len(text_a.strip())}, B={len(text_b.strip())} chars). Treating as draw."
+            )
+            return 0.5, 0.5, 0.0
+        if a_short:
+            # A만 짧음: B 무조건 승리
+            logger.info(
+                f"⏭️ Text A too short ({len(text_a.strip())} chars). B wins by forfeit in PAIRS."
+            )
+            return 0.0, 1.0, 0.0
+        if b_short:
+            # B만 짧음: A 무조건 승리
+            logger.info(
+                f"⏭️ Text B too short ({len(text_b.strip())} chars). A wins by forfeit in PAIRS."
+            )
+            return 1.0, 0.0, 0.0
+
         sys_prompt = self._get_system_prompt(criteria)
 
         # Prompt 1: A first, B second

--- a/ai_server/app/workers/challenge_feedback_worker.py
+++ b/ai_server/app/workers/challenge_feedback_worker.py
@@ -151,7 +151,10 @@ async def _generate_pvp_feedback(
             text = text.strip()
         parsed = json.loads(text)
         # user_B 부분만 추출하여 반환 (현재 유저 = user_B)
-        return parsed.get("user_B", parsed)
+        user_b = parsed.get("user_B", parsed)
+        user_b.pop("user_id", None)
+        user_b.pop("score", None)
+        return user_b
     except (json.JSONDecodeError, AttributeError) as e:
         logger.error(f"Failed to parse PvP feedback JSON: {e}")
         return {

--- a/ai_server/app/workers/challenge_stt_worker.py
+++ b/ai_server/app/workers/challenge_stt_worker.py
@@ -83,11 +83,15 @@ async def handle_challenge_stt_message(
         language="ko",
     )
 
+    stt_text = stt_result.get("text", "").strip()
+    if not stt_text:
+        stt_text = "[NO_ANSWER]"
+
     response = ChallengeSTTResponse(
         attemptId=request.attemptId,
         challengeId=request.challengeId,
         status="SUCCESS",
-        sttText=stt_result.get("text", ""),
+        sttText=stt_text,
     )
 
     await rabbitmq_service.publish(


### PR DESCRIPTION
## 변경 사항

### 🔇 챌린지 모드 무발화 유저 패배 처리
- STT 결과가 빈 문자열인 경우 `[NO_ANSWER]`로 마킹하도록 변경 (`challenge_stt_worker.py`)
- PAIRS 비교 프롬프트에 최우선 규칙 추가: `[NO_ANSWER]`인 답변은 즉시 패배 처리 (`prompts.py`)
- 기존 5자 미만 즉시 패배 로직(`pairs_service.py`)과 함께 이중 방어 구조 적용

### 📐 피드백 형식 통일 (Rank 1 ↔ Rank 2~N)
- Rank 2~N 피드백(`_generate_pvp_feedback`)에서 `user_id`, `score` 필드 제거
- 모든 등수의 `feedback_json` 구조를 동일하게 통일

## 테스트 체크리스트
- [x] 음성을 녹음하지 않은 유저가 챌린지 모드에서 패배하는지 확인
- [x] Redis `challenge:{job_id}:feedbacks`에 저장된 모든 등수의 `feedback_json` 구조 확인
- [x] Rank 1(솔로 피드백)과 Rank 2+(PvP 피드백) 필드 구조가 동일한지 확인
