### PR TITLE
fix: convert _handle_promote to iteration with exact max_level termin…

### DIFF
--- a/ai_server/app/workers/challenge_worker.py
+++ b/ai_server/app/workers/challenge_worker.py
@@ -219,55 +219,71 @@ async def _handle_promote(
     target_count: int,
 ):
     """
-    부전승 노드를 한 레벨 위로 재귀적으로 올려보냅니다.
-    최종 목표에 도달하면 랭킹 완료 처리합니다.
+    부전승 노드를 상위 레벨로 올립니다. 재귀 대신 이터레이션으로 구현하여
+    expected_count=1 상황에서의 무한 루프를 방지합니다.
+
+    max_level = ceil(log2(N)): N명 토너먼트의 정확한 라운드 수.
+    이 레벨을 초과하면 더 이상 짝이 올 수 없으므로 랭킹 완료 처리합니다.
     """
-    if len(promoted_ids) >= target_count:
-        await _handle_ranking_complete(job_id, knowledge_id, promoted_ids, target_count)
-        return
+    max_level = math.ceil(math.log2(max(target_count, 2)))
 
-    upper_level = current_level + 1
-    upper_expected = _calc_expected_count(current_expected)
-    list_key = f"pairs:{job_id}:level:{upper_level}"
-    arrived_key = f"pairs:{job_id}:level:{upper_level}:arrived"
-    serialized = json.dumps(promoted_ids, ensure_ascii=False)
+    level = current_level
+    expected = current_expected
+    ids = promoted_ids
 
-    action, data = await redis_lua.push_and_route(
-        list_key=list_key,
-        arrived_key=arrived_key,
-        serialized_array=serialized,
-        expected_count=upper_expected,
-    )
+    while True:
+        if len(ids) >= target_count:
+            await _handle_ranking_complete(job_id, knowledge_id, ids, target_count)
+            return
 
-    if action == "PAIR":
-        new_arr_a = json.loads(data[0])
-        new_arr_b = json.loads(data[1])
-        next_mission = {
-            "job_id": job_id,
-            "knowledgeBase_id": knowledge_id,
-            "level": upper_level,
-            "array_a": new_arr_a,
-            "array_b": new_arr_b,
-            "target_count": target_count,
-            "expected_count": upper_expected,
-        }
-        logger.info(f"Level UP ⬆️ PAIR after PROMOTE at Level {upper_level}")
-        await rabbitmq_service.publish(settings.CHALLENGE_MERGE_QUEUE, next_mission)
+        upper_level = level + 1
+        if upper_level > max_level:
+            logger.info(
+                f"[{job_id}] PROMOTE reached tournament root "
+                f"(level {upper_level} > max_level {max_level} = ceil(log2({target_count}))). "
+                f"Ranking complete."
+            )
+            await _handle_ranking_complete(job_id, knowledge_id, ids, target_count)
+            return
 
-    elif action == "PROMOTE":
-        # 연쇄 부전승 → 재귀 호출
-        re_promoted = json.loads(data[0])
-        logger.info(f"🏅 Cascading PROMOTE at Level {upper_level}")
-        await _handle_promote(
-            job_id,
-            knowledge_id,
-            re_promoted,
-            upper_level,
-            upper_expected,
-            target_count,
+        upper_expected = _calc_expected_count(expected)
+        list_key = f"pairs:{job_id}:level:{upper_level}"
+        arrived_key = f"pairs:{job_id}:level:{upper_level}:arrived"
+        serialized = json.dumps(ids, ensure_ascii=False)
+
+        action, data = await redis_lua.push_and_route(
+            list_key=list_key,
+            arrived_key=arrived_key,
+            serialized_array=serialized,
+            expected_count=upper_expected,
         )
-    else:
-        logger.info(f"⏳ WAIT after PROMOTE at Level {upper_level}")
+
+        if action == "PAIR":
+            new_arr_a = json.loads(data[0])
+            new_arr_b = json.loads(data[1])
+            next_mission = {
+                "job_id": job_id,
+                "knowledgeBase_id": knowledge_id,
+                "level": upper_level,
+                "array_a": new_arr_a,
+                "array_b": new_arr_b,
+                "target_count": target_count,
+                "expected_count": upper_expected,
+            }
+            logger.info(f"Level UP PAIR after PROMOTE at Level {upper_level}")
+            await rabbitmq_service.publish(settings.CHALLENGE_MERGE_QUEUE, next_mission)
+            return
+
+        elif action == "PROMOTE":
+            ids = json.loads(data[0])
+            level = upper_level
+            expected = upper_expected
+            logger.info(f"Cascading PROMOTE at Level {upper_level}")
+            # continue loop
+
+        else:  # WAIT
+            logger.info(f"WAIT after PROMOTE at Level {upper_level}")
+            return
 
 
 async def _handle_ranking_complete(


### PR DESCRIPTION
## 요약

- **버그**: `_handle_promote`의 재귀 호출이 `expected_count=1`일 때 `ceil(1/2)=1`로 수렴하여 `maximum recursion depth exceeded` 발생
- **원인**: 종료 조건(`len(ids) >= target_count`)이 부전승 단일 노드에서 절대 충족되지 않아 무한 재귀
- **수정**: 재귀 → `while` 이터레이션 전환 + `max_level = ceil(log2(target_count))`로 정확한 종료 보장

## 변경 내용

### `app/workers/challenge_worker.py`
- `_handle_promote` 재귀 호출 제거, `while True` 이터레이션으로 교체
- `max_level = math.ceil(math.log2(max(target_count, 2)))` — N명 토너먼트의 수학적으로 정확한 최대 라운드 수
- `upper_level > max_level` 도달 시 더 이상 짝이 올 수 없으므로 즉시 `_handle_ranking_complete` 호출
- 기존 `+5` 버퍼 제거 (근거 없는 임시값)

### `tests/workers/test_challenge_worker.py`
- `TestHandlePromote` 테스트 클래스 추가 (7개 케이스)
  - `max_level` 공식 검증 (N=2, 3, 4, 5, 8, 100)
  - 무한 루프 회귀 테스트: `expected_count=1`에서 Lua 정확히 2번 호출 후 종료
  - N=3(max_level=2), N=5(max_level=3) 케이스별 Lua 호출 횟수 검증
  - PROMOTE→WAIT, PROMOTE→PAIR 정상 경로
  - 즉시 완료 조건 (`len(ids) >= target_count`)

## 테스트