### PR TITLE
perf: switch PAIRS service to async client and disable thinking mode

### DIFF
--- a/ai_server/app/services/pairs_service.py
+++ b/ai_server/app/services/pairs_service.py
@@ -99,17 +99,17 @@ class PairsService:
             response_schema=RESPONSE_SCHEMA,
             response_logprobs=True,
             logprobs=5,
+            thinking_config=types.ThinkingConfig(thinking_budget=0),
         )
 
         async with self.api_semaphore:
             response = await asyncio.wait_for(
-                asyncio.to_thread(
-                    client.models.generate_content,
+                client.aio.models.generate_content(
                     model=settings.PAIRS_MODEL_ID,
                     contents=prompt,
                     config=config,
                 ),
-                timeout=20.0,
+                timeout=60.0,
             )
 
         logprobs_data = []
@@ -259,4 +259,4 @@ class PairsService:
             beam = new_beam[: self.beam_size]
 
 
-pairs_service = PairsService()
+pairs_service = PairsService(beam_size=3)


### PR DESCRIPTION
## 요약
- PAIRS 서비스 LLM 호출 방식을 동기 → 비동기(native async) 클라이언트로 전환
- Gemini 2.5 Flash의 thinking 모드 비활성화(thinking_budget=0)로 응답 지연 개선
- 프로덕션에서 발생한 20초 타임아웃 에러 원인 해소 (60초로 상향)
- beam_size 5→3 조정으로 LLM 호출 수 감소

## 변경 배경
프로덕션 로그에서 `asyncio.TimeoutError`(에러 메시지 빈 문자열)가 반복 발생.
원인 분석 결과 두 가지 문제 발견:
1. `asyncio.to_thread`로 동기 SDK를 감싸는 방식이 타임아웃 시 스레드를 종료하지 못해 좀비 요청 누적
2. Gemini 2.5 Flash의 기본 thinking 모드가 응답 시간을 30~60초로 증가

## 테스트
- N=5 로컬 통합 테스트 스크립트(`scripts/seed_n5_test.py`) 추가
- 유닛 테스트 17개 전원 통과 확인

## 주의사항
- `thinking_budget=0`은 정확도보다 속도를 우선하는 설정으로, 추후 서비스 안정화 후 재검토 필요
- beam_size=3은 프로덕션 환경에서 추가 조정 가능