### PR TITLE
implement in-memory audio pipeline to bypass disk I/O

### DIFF
--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -1122,4 +1122,83 @@ Redis hanging을 계기로 전체 외부 API 호출에 timeout이 없는 지점�
 - AWS ElastiCache 생성 시 **In-Transit Encryption(TLS)이 기본값 Enabled**. `redis://` 대신 `rediss://`를 사용해야 함.
 - `socket_timeout` 부재 시 TLS 불일치 같은 연결 이상이 **에러 로그 없이 무한 hanging**으로 나타남. 모든 외부 I/O에 반드시 timeout을 설정할 것.
 - timeout은 단순히 에러를 내는 것 이상으로, **문제를 가시화하는 디버깅 도구** 역할을 함.
+
+---
+
+## 35. Prod Kubernetes: GCP_SA_JSON_STR 파싱 실패 (Vertex AI 클라이언트 초기화 오류)
+
+### 35.1. 증상
+
+```
+ERROR:imyme-pairs-service:Failed to initialize Vertex AI client: Expecting value: line 1 column 1 (char 0)
+```
+
+Vertex AI 클라이언트가 초기화되지 않고 fallback `genai.Client()` (인증 없음)로 동작. 실제 LLM 호출 시 인증 오류 발생.
+
+### 35.2. 원인
+
+**Release 환경과 Prod 환경의 환경변수 주입 방식 차이.**
+
+| 환경 | 주입 방식 | 따옴표 처리 |
+|---|---|---|
+| Release 서버 | CI/CD가 SSH로 `.env` 파일에 직접 씀 | pydantic-settings가 `.env` 파싱 시 **자동 제거** |
+| Prod (Kubernetes) | External Secrets Operator → SSM → K8s Secret → env var | **그대로 주입** (제거 안 함) |
+
+`.env` 파일 형식:
+```env
+GCP_SA_JSON_STR = '{"type":"service_account",...}'
+```
+
+이 값을 SSM에 등록할 때 앞뒤 `'`(작은따옴표)까지 포함해서 저장하면:
+- Release: pydantic이 `.env`를 읽으면서 따옴표를 자동 제거 → `json.loads` 성공
+- Prod: env var로 주입된 값이 `'{"type":...}'` → 첫 글자가 `'` → `json.loads` char 0에서 실패
+
+### 35.3. 진단 방법
+
+```bash
+# K8s Secret에 저장된 실제 값 확인
+kubectl get secret ai-secret -n mine-app \
+  -o jsonpath='{.data.GCP_SA_JSON_STR}' | base64 -d | head -c 5
+# '{"ty 로 시작하면 따옴표 포함된 것 → 문제
+# {"typ 로 시작하면 정상
+```
+
+```bash
+# SSM 파라미터 값 직접 확인
+aws ssm get-parameter \
+  --name "/MINE/MVP1/AI/ENV/COMMON/GCP_SA_JSON_STR" \
+  --with-decryption \
+  --query "Parameter.Value" \
+  --output text | cut -c1-5
+```
+
+### 35.4. 해결 방법
+
+SSM 파라미터를 **따옴표 없는 순수 JSON**으로 재등록:
+
+```bash
+aws ssm put-parameter \
+  --name "/MINE/MVP1/AI/ENV/COMMON/GCP_SA_JSON_STR" \
+  --value '{"type":"service_account","project_id":"..."}' \
+  --type SecureString \
+  --overwrite
+```
+
+즉시 동기화 (기본 refreshInterval 1h 대기 없이):
+```bash
+kubectl annotate externalsecret ai-secret -n mine-app \
+  force-sync=$(date +%s) --overwrite
+```
+
+Pod 재시작 후 확인:
+```bash
+kubectl rollout restart deployment ai -n mine-app
+kubectl logs -n mine-app -l app=ai --tail=50 | grep -i "vertex\|successful"
+# "Successfully initialized Vertex AI client using Service Account JSON String." 확인
+```
+
+### 35.5. 교훈 (Lesson Learned)
+- SSM 파라미터 등록 시 `.env` 파일 형식(`KEY = 'value'`)을 그대로 복붙하면 따옴표가 값에 포함됨. **SSM에는 값만 저장해야 함.**
+- pydantic-settings는 `.env` 파일 읽을 때만 따옴표를 자동 제거함. **환경변수로 주입된 값은 그대로 사용**하므로 두 환경의 동작이 달라짐.
+- Kubernetes 환경에서는 `.env` 파일이 존재하지 않으므로 SSM/Secret 값이 유일한 소스. SSM 등록 전 반드시 `| base64 -d | head -c 5`로 첫 글자 검증 필요.
 - Vertex AI 클라이언트 초기화 실패가 로그에 남지 않을 수 있음 (모듈 임포트 시점에 로깅 핸들러가 미설정 상태). 초기화 오류 추적은 `docker logs` 직접 확인 필요.

--- a/stt_server/services/inference_service.py
+++ b/stt_server/services/inference_service.py
@@ -19,22 +19,20 @@ class InferenceService:
     # Main method to transcribe audio from a URL
     def transcribe(self, audio_url: str, language: str = None) -> dict:
         start_time = time.time()
-        temp_file_path = None
 
         try:
-            # 1. Download audio file
+            # 1. Download audio into memory (no disk I/O)
             logger.info(f"Downloading audio from {audio_url}")
-            temp_file_path = self.audio_loader.download_audio(audio_url)
+            audio_buffer = self.audio_loader.download_audio(audio_url)
 
             # 2. Get Model
             model = self.model_service.get_model()
 
-            # 3. Transcribe
+            # 3. Transcribe directly from in-memory buffer
+            # faster-whisper accepts BinaryIO (io.BytesIO) via av.open() internally
             logger.info("Starting transcription...")
-            # beam_size=5 is a common default
-            # Updated with VAD & Hallucination Prevention settings
             segments_generator, info = model.transcribe(
-                temp_file_path,
+                audio_buffer,
                 beam_size=5,
                 language=language,
                 # [VAD & Hallucination Prevention]
@@ -68,7 +66,3 @@ class InferenceService:
         except Exception as e:
             logger.error(f"Transcription failed: {e}")
             raise e
-        finally:
-            # 5. Cleanup
-            if temp_file_path:
-                self.audio_loader.cleanup_file(temp_file_path)

--- a/stt_server/utils/audio_loader.py
+++ b/stt_server/utils/audio_loader.py
@@ -1,57 +1,27 @@
+import io
 import requests
-import tempfile
-import os
 
 
-# Service class for handling audio file operations
-# 오디오 파일 작업을 처리하는 서비스 클래스
 class AudioLoader:
     def __init__(self):
-        # Chunk size for streaming downloads (8KB)
-        # 스트리밍 다운로드를 위한 청크 크기 (8KB)
         self.chunk_size = 8192
 
-    # Downloads audio from a URL to a temporary file
-    # URL에서 오디오를 다운로드하여 임시 파일로 저장하는 메서드
-    def download_audio(self, url: str) -> str:
+    def download_audio(self, url: str) -> io.BytesIO:
         try:
-            # Create a GET request with stream=True to handle large files efficiently
-            # 대용량 파일을 효율적으로 처리하기 위해 stream=True로 GET 요청 생성
             response = requests.get(url, stream=True)
             response.raise_for_status()
 
-            # Determine file extension from URL (strip query params)
-            # URL에서 파일 확장자를 추출 (쿼리 파라미터 제거)
-            clean_url = url.split("?")[0]
-            ext = os.path.splitext(clean_url)[1] or ".mp3"
-
-            # Create a temporary file to save the downloaded content
-            # 다운로드한 내용을 저장할 임시 파일 생성
-            # delete=False ensures the file exists after closing, so we can pass the path to Whisper
-            # delete=False는 파일을 닫은 후에도 유지하여 Whisper에 경로를 전달할 수 있게 함
-            with tempfile.NamedTemporaryFile(delete=False, suffix=ext) as temp_file:
-                for chunk in response.iter_content(chunk_size=self.chunk_size):
-                    if chunk:
-                        temp_file.write(chunk)
-
-                # Return the absolute path of the temporary file
-                # 임시 파일의 절대 경로 반환
-                return temp_file.name
+            buffer = io.BytesIO()
+            for chunk in response.iter_content(chunk_size=self.chunk_size):
+                if chunk:
+                    buffer.write(chunk)
+            buffer.seek(0)
+            return buffer
 
         except requests.RequestException as e:
-            # Raise an exception if download fails
-            # 다운로드 실패 시 예외 발생
             raise RuntimeError(f"Failed to download audio: {str(e)}")
         except Exception as e:
-            # Raise generic exception for file IO errors
-            # 파일 IO 오류 등 일반적인 예외 처리
-            raise RuntimeError(f"Error saving audio file: {str(e)}")
-
-    # Clean up the temporary file
-    # 임시 파일 정리(삭제) 메서드
-    def cleanup_file(self, file_path: str):
-        if os.path.exists(file_path):
-            os.remove(file_path)
+            raise RuntimeError(f"Error loading audio into memory: {str(e)}")
 
 
 # Global instance


### PR DESCRIPTION
## 💡 배경 및 목적
- STT 서버가 GPU(RunPod) 환경에서 외부(S3 등)로부터 오디오 파일 URL을 전달받아 전사 작업을 수행할 때, 파일을 로컬 디스크의 임시 폴더에 다운로드 후 다시 디스크에서 읽어 모델에 전달하는 이중 과정이 있었습니다.
- 고성능 GPU 연산 전에 발생하는 **디스크 I/O 병목(Bottleneck)** 과 한정된 컨테이너 디스크 공간 문제를 해결하고, 전체 파이프라인의 처리 속도(Latency)를 단축하고자 코드를 리팩토링했습니다.

## 🛠️ 주요 수정 내역 (구현 로직)
`utils/audio_loader.py`에 In-Memory 파이프라인 적용 (`AudioLoader` 클래스 구현)

- **Disk I/O 완전 제거**: `os`나 `tempfile` 모듈을 통한 물리적 파일 저장 로직을 전면 제거했습니다.
- **`io.BytesIO` 버퍼링**: `requests.get(stream=True)`를 통해 넘겨받은 바이너리 스트림 데이터를 RAM(`io.BytesIO()`)에 직접 기록합니다.
- **스트리밍 최적화**: 메모리 오버플로우를 막고 네트워크 안전성을 확보하기 위해 `chunk_size(8192)` 단위의 청크(Chunk) 스트리밍 방식을 적용하여 순차적으로 버퍼에 적재합니다. 
- **모델 직접 전달**: 버퍼에 모두 담은 후 `buffer.seek(0)`로 포인터를 초기화하여 반환하며, `faster-whisper`의 `transcribe` 메서드는 `BinaryIO` 입력을 기본 지원하므로 메모리 버퍼를 그대로 모델에 전달합니다.

## 🧪 기대 효과 (테스트/성능 관점)
- 오디오 다운로드 후 디스크 쓰기 시간 및 디스크에서 메모리로 다시 올리는 읽기 시간이 사라져 STT 전사 처리까지 걸리는 **End-to-End Latency가 유의미하게 감소**합니다.
- 동시 접속 증가나 컨테이너 스케일링 시 발생할 수 있는 스토리지 용량 고갈 또는 느린 디스크 속도로 인한 타임아웃 오류를 원천 차단했습니다.

## 📌 리뷰어 참고 사항
- 메모리 사용량이 파일 크기에 비례하여 다소 증가하므로 대용량 오디오(예: 수십 MB 이상) 요청 시 워커 노드(RunPod)의 RAM 사용률 모니터링이 필요할 수 있습니다. 메인 서비스인 MINE의 제한 시간(1분 이내 발화)에서는 전혀 문제되지 않습니다.
