### PR TITLE
feat(solo): add global deadline & phase budget for STT->Gemini pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ build/
 # Tests
 tests/
 pytest.ini
+
+ARCHITECTURE_SUMMARY.md

--- a/ai_server/app/schemas/solo_mq_schema.py
+++ b/ai_server/app/schemas/solo_mq_schema.py
@@ -27,6 +27,10 @@ class SoloSTTRequest(BaseModel):
     user_id: int = Field(..., description="사용자 ID (Pass-through)")
     audio_url: str = Field(..., description="S3 오디오 파일 URL")
     timestamp: int = Field(..., description="요청 시간 (Unix timestamp)")
+    expires_at: Optional[float] = Field(
+        None,
+        description="글로벌 데드라인 (Unix timestamp). 이 시각을 넘기면 처리를 포기합니다.",
+    )
 
 
 class SoloSTTResponse(BaseModel):
@@ -66,6 +70,10 @@ class SoloFeedbackRequest(BaseModel):
         default_factory=list, description="이전 피드백 기록 리스트"
     )
     timestamp: int = Field(..., description="요청 시간 (Unix timestamp)")
+    expires_at: Optional[float] = Field(
+        None,
+        description="글로벌 데드라인 (Unix timestamp). 이 시각을 넘기면 처리를 포기합니다.",
+    )
 
 
 class SoloFeedbackData(BaseModel):

--- a/ai_server/app/services/runpod_client.py
+++ b/ai_server/app/services/runpod_client.py
@@ -26,7 +26,9 @@ class RunPodClient:
     # ──────────────────────────────────────────────
     # Public API — Pod 우선, Serverless 폴백
     # ──────────────────────────────────────────────
-    async def transcribe(self, audio_url: str, language: str = None) -> dict:
+    async def transcribe(
+        self, audio_url: str, language: str = None, timeout: float | None = None
+    ) -> dict:
         if not self.endpoint_id or not self.api_key:
             logger.warning("RunPod credentials not set. Returning mock response.")
             return self._mock_response(audio_url)
@@ -34,7 +36,7 @@ class RunPodClient:
         # 1️⃣ Pod가 설정되어 있으면 우선 시도
         if self.pod_url:
             try:
-                return await self._call_pod(audio_url, language)
+                return await self._call_pod(audio_url, language, timeout=timeout)
             except Exception as e:
                 logger.warning(
                     f"Pod request failed ({e}). Falling back to Serverless..."
@@ -46,12 +48,15 @@ class RunPodClient:
     # ──────────────────────────────────────────────
     # Pod — Direct HTTP POST to FastAPI
     # ──────────────────────────────────────────────
-    async def _call_pod(self, audio_url: str, language: str = None) -> dict:
+    async def _call_pod(
+        self, audio_url: str, language: str = None, timeout: float | None = None
+    ) -> dict:
         url = f"{self.pod_url.rstrip('/')}/transcribe"
         payload = {"audio_url": audio_url, "language": language}
 
-        logger.info(f"Sending request to Pod: {url}")
-        async with httpx.AsyncClient(timeout=self.pod_timeout) as client:
+        effective_timeout = timeout if timeout is not None else self.pod_timeout
+        logger.info(f"Sending request to Pod: {url} (timeout={effective_timeout}s)")
+        async with httpx.AsyncClient(timeout=effective_timeout) as client:
             response = await client.post(url, json=payload)
             response.raise_for_status()
 

--- a/ai_server/app/workers/solo_feedback_worker.py
+++ b/ai_server/app/workers/solo_feedback_worker.py
@@ -17,6 +17,7 @@ by rabbitmq_service.py on the 3rd (final) failure attempt.
 """
 
 import asyncio
+import time
 import logging
 
 from aio_pika.abc import AbstractIncomingMessage
@@ -61,11 +62,28 @@ async def handle_solo_feedback_message(
         f"[Solo Feedback Worker] Processing attempt={request.attempt_id}, user={request.user_id}"
     )
 
-    # 2. Validate criteria
+    # 2. Global Deadline Budget Check
+    # expires_at이 존재하면 남은 시간을 확인하고, 부족하면 Gemini를 호출하지 않음
+    gemini_timeout: float | None = None  # None이면 기존 동작(무제한 대기)
+    if request.expires_at is not None:
+        remaining_time = request.expires_at - time.time()
+
+        if remaining_time <= 0:
+            raise TimeoutError(
+                f"[Global Deadline] Feedback 예산 만료. Gemini API를 호출하지 않습니다. "
+                f"(remaining={remaining_time:.1f}s)"
+            )
+
+        gemini_timeout = remaining_time
+        logger.info(
+            f"[Solo Feedback Worker] Budget allocated: gemini_timeout={gemini_timeout:.1f}s"
+        )
+
+    # 3. Validate criteria
     if not request.criteria:
         raise ValueError("분석 기준(Criteria)이 누락되었습니다.")
 
-    # 3. Handle short text (hardcoded response, not an error)
+    # 4. Handle short text (hardcoded response, not an error)
     if len(request.stt_text.strip()) < MIN_TEXT_LENGTH:
         logger.info(
             f"[Solo Feedback Worker] Text too short (<{MIN_TEXT_LENGTH} chars). "
@@ -94,12 +112,25 @@ async def handle_solo_feedback_message(
         )
         return
 
-    # 4. Run Scoring + Feedback in parallel (same as analysis_service logic)
+    # 5. Run Scoring + Feedback in parallel (same as analysis_service logic)
     score_task = scoring_service.evaluate(request.stt_text, request.criteria)
     feedback_task = feedback_service.generate_feedback(
         request.stt_text, request.criteria, request.history
     )
-    score_result, feedback_result = await asyncio.gather(score_task, feedback_task)
+
+    # Global Deadline이 설정되어 있으면 asyncio.wait_for로 하드 타임아웃 적용
+    if gemini_timeout is not None:
+        try:
+            score_result, feedback_result = await asyncio.wait_for(
+                asyncio.gather(score_task, feedback_task),
+                timeout=gemini_timeout,
+            )
+        except asyncio.TimeoutError:
+            raise TimeoutError(
+                f"[Global Deadline] Gemini 응답이 예산({gemini_timeout:.1f}s) 내에 완료되지 않았습니다."
+            )
+    else:
+        score_result, feedback_result = await asyncio.gather(score_task, feedback_task)
 
     # 5. Build and publish SUCCESS response
     response = SoloFeedbackResponse(

--- a/ai_server/app/workers/solo_stt_worker.py
+++ b/ai_server/app/workers/solo_stt_worker.py
@@ -14,6 +14,7 @@ by rabbitmq_service.py on the 3rd (final) failure attempt.
 """
 
 import re
+import time
 import logging
 
 from aio_pika.abc import AbstractIncomingMessage
@@ -24,6 +25,12 @@ from app.services.runpod_client import runpod_client
 from app.schemas.solo_mq_schema import SoloSTTRequest, SoloSTTResponse
 
 logger = logging.getLogger(__name__)
+
+# ── Global Deadline Budget Constants ──
+# Gemini(Feedback)가 실행될 수 있도록 최소한 확보해야 하는 시간
+GEMINI_MIN_RESERVED_SECONDS = 15.0
+# STT 단계에 배분할 수 있는 최대 예산
+STT_MAX_BUDGET_SECONDS = 40.0
 
 # Supported audio file extensions
 # 지원 오디오 포맷 목록
@@ -56,8 +63,9 @@ async def handle_solo_stt_message(body: dict, message: AbstractIncomingMessage) 
     Callback function to process a Solo STT request message.
 
     1. Parse and validate the message body (URL format + extension)
-    2. Call the RunPod STT server to extract text
-    3. Publish a SUCCESS SoloSTTResponse to the result queue
+    2. [NEW] Check global deadline budget — skip STT if insufficient time remains
+    3. Call the RunPod STT server for speech-to-text conversion
+    4. Publish a SUCCESS SoloSTTResponse to the result queue
 
     On failure, the exception is re-raised to trigger the RabbitMQ
     retry mechanism (up to 3 attempts with 5s delay between each).
@@ -72,20 +80,42 @@ async def handle_solo_stt_message(body: dict, message: AbstractIncomingMessage) 
         f"[Solo STT Worker] Processing attempt={request.attempt_id}, user={request.user_id}"
     )
 
-    # 2. Validate URL format
+    # 2. Global Deadline Budget Check
+    # Gemini 최소 보장 시간(15초)을 확보하고, STT는 최대 40초까지만 사용 가능
+    stt_timeout: float | None = None  # None이면 기존 기본 타임아웃 사용
+    if request.expires_at is not None:
+        remaining_time = request.expires_at - time.time()
+        stt_budget = min(
+            remaining_time - GEMINI_MIN_RESERVED_SECONDS, STT_MAX_BUDGET_SECONDS
+        )
+
+        if stt_budget <= 0:
+            raise TimeoutError(
+                f"[Global Deadline] STT 예산 부족으로 처리를 건너뜁니다. "
+                f"(remaining={remaining_time:.1f}s, required>{GEMINI_MIN_RESERVED_SECONDS}s)"
+            )
+
+        stt_timeout = stt_budget
+        logger.info(
+            f"[Solo STT Worker] Budget allocated: stt_timeout={stt_timeout:.1f}s "
+            f"(remaining={remaining_time:.1f}s)"
+        )
+
+    # 3. Validate URL format
     if not URL_PATTERN.match(request.audio_url):
         raise ValueError(f"유효한 URL인지 확인하세요. (input: {request.audio_url})")
 
-    # 3. Validate file extension
+    # 4. Validate file extension
     clean_url = request.audio_url.split("?")[0].lower()
     if not any(clean_url.endswith(ext) for ext in SUPPORTED_FORMATS):
         detected_ext = clean_url.split(".")[-1] if "." in clean_url else "unknown"
         raise ValueError(f"지원하지 않는 오디오 포맷입니다. ({detected_ext})")
 
-    # 4. Call RunPod STT (natively async)
+    # 5. Call RunPod STT (natively async) with dynamic timeout
     stt_result = await runpod_client.transcribe(
         audio_url=request.audio_url,
         language="ko",
+        timeout=stt_timeout,
     )
 
     # 5. Build and publish SUCCESS response


### PR DESCRIPTION
## Summary

Solo 모드의 STT → Gemini Feedback 순차 파이프라인에
**글로벌 데드라인(Global Deadline & Phase Limits)** 방어 메커니즘을 도입합니다.

### 배경 / 문제

기존 구조에서는 아래 상황에서 불필요한 Gemini API 비용이 발생했습니다.
- STT가 재시도를 반복하며 50초를 소진한 뒤 Feedback 단계에 진입
- RabbitMQ 큐 대기 시간이 길어져 어차피 실패할 요청을 처리

### 해결 방법 (Option 3.1)

외부 서버가 최초 STT 요청 시 `expires_at = now + 55s`를 주입하고,
Feedback 요청 시에도 **동일한 `expires_at`을 그대로 전달**합니다.
각 워커는 메시지 처리 직전에 남은 예산을 확인하여 드롭 여부를 결정합니다.

STT Budget = min(remaining - 15s, 40s) ← 뒤 Gemini 보장 15초 확보 Gemini 체크 = remaining > 0 이어야 호출 ← 비용 방어


### 변경된 파일

| 파일 | 변경 내용 |
|---|---|
| `app/schemas/solo_mq_schema.py` | `expires_at: Optional[float]` 필드 추가 |
| `app/services/runpod_client.py` | `transcribe(timeout=)` 동적 파라미터 추가 |
| `app/workers/solo_stt_worker.py` | 예산 계산 + 부족 시 pre-drop 로직 |
| `app/workers/solo_feedback_worker.py` | 만료 시 Gemini 미호출 + `wait_for` 하드 타임아웃 |

### 테스트

tests/workers/test_solo_stt_worker_deadline.py (10 cases) tests/workers/test_solo_feedback_worker_deadline.py (9 cases) ───────────────────────────────────────────────────────────── 19 passed in 3.68s ✅


**커버된 엣지케이스:**
- `expires_at` 없음 → 기존 동작 유지 (하위 호환)
- 잔여 예산 = 정확히 15초 → budget = 0, STT 드롭
- MQ 대기 중 만료 → 워커 실행 시점에 이미 만료, 즉시 드롭
- Gemini 응답이 예산 초과 → `asyncio.TimeoutError` 정상 처리
- RunPod HTTP 타임아웃 → 외부 예외 전파, RabbitMQ 재시도 위임

### 외부 연동 필요 사항

> **BE 팀 액션 필요**
> - STT 요청 시: `"expires_at": time.time() + 55` 추가
> - Feedback 요청 시: STT에 사용한 **동일한 `expires_at` 값** 재사용
> - 값이 없으면 기존과 100% 동일하게 동작 (breaking change 없음)
